### PR TITLE
[FEAT/#62] 기록하기 뷰 로직 구현

### DIFF
--- a/app/src/main/java/com/bongtu/baekseo/core/common/type/AttendType.kt
+++ b/app/src/main/java/com/bongtu/baekseo/core/common/type/AttendType.kt
@@ -1,0 +1,8 @@
+package com.bongtu.baekseo.core.common.type
+
+enum class AttendType(
+    val label: String,
+) {
+    ATTEND(label = "참석"),
+    ABSENT(label = "불참석");
+}

--- a/app/src/main/java/com/bongtu/baekseo/presentation/edit/EditMainScreen.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/edit/EditMainScreen.kt
@@ -63,6 +63,7 @@ import com.bongtu.baekseo.R.string.edit_relation_dropdown_placeholder
 import com.bongtu.baekseo.R.string.edit_relation_title
 import com.bongtu.baekseo.R.string.edit_required_text
 import com.bongtu.baekseo.R.string.edit_save_button
+import com.bongtu.baekseo.core.common.type.AttendType
 import com.bongtu.baekseo.core.common.type.DatePickerDialogType
 import com.bongtu.baekseo.core.common.type.EventType
 import com.bongtu.baekseo.core.common.type.RelationType
@@ -79,7 +80,6 @@ import com.bongtu.baekseo.presentation.edit.component.EditCostLabelTextField
 import com.bongtu.baekseo.presentation.edit.component.EditLocationContent
 import com.bongtu.baekseo.presentation.edit.component.EditMemoContent
 import com.bongtu.baekseo.presentation.edit.type.EditType
-import com.bongtu.baekseo.presentation.record.type.AttendType
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 

--- a/app/src/main/java/com/bongtu/baekseo/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/main/MainScreen.kt
@@ -143,7 +143,7 @@ private fun MainNavHost(
                     }
                 )
             },
-            navigateToEdit = navigator.navController::navigateToEdit,
+            navigateToEdit = navigator.navController::navigateToEdit, // TODO: Caching
             modifier = modifier,
         )
 
@@ -155,12 +155,14 @@ private fun MainNavHost(
                 )
             },
             navigateToAdd = navigator.navController::navigateToEdit,
+            innerPadding = innerPadding,
+            bottomPadding = innerPadding.calculateBottomPadding(),
             modifier = modifier,
         )
 
         detailGraph(
             navigateUp = navigator::navigateUp,
-            navigateToEdit = navigator.navController::navigateToEdit,
+            navigateToEdit = navigator.navController::navigateToEdit,  // TODO: Caching
             navigateToRecord = {
                 navigator.navController.navigateToRecord(
                     navOptions = navOptions {
@@ -184,7 +186,7 @@ private fun MainNavHost(
                         popUpTo<Edit> {
                             inclusive = true
                         }
-                    }
+                    },
                 )
             },
             navigateToRecord = {

--- a/app/src/main/java/com/bongtu/baekseo/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/main/MainScreen.kt
@@ -156,7 +156,6 @@ private fun MainNavHost(
             },
             navigateToAdd = navigator.navController::navigateToEdit,
             innerPadding = innerPadding,
-            bottomPadding = innerPadding.calculateBottomPadding(),
             modifier = modifier,
         )
 

--- a/app/src/main/java/com/bongtu/baekseo/presentation/record/RecordContract.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/record/RecordContract.kt
@@ -3,16 +3,24 @@ package com.bongtu.baekseo.presentation.record
 import androidx.compose.runtime.Immutable
 import com.bongtu.baekseo.core.common.state.UiState
 import com.bongtu.baekseo.data.model.RecordEvent
-import com.bongtu.baekseo.presentation.record.type.AttendType
+import com.bongtu.baekseo.core.common.type.AttendType
 import com.bongtu.baekseo.presentation.record.type.EventCategoryType
 
 class RecordContract {
     @Immutable
-    data class RecordState(
+    data class RecordUiState(
         val recordLoadState: UiState<List<RecordEvent>> = UiState.Loading,
         val selectedDeleteEventIds: Set<String> = emptySet(),
         val attendType: AttendType = AttendType.ATTEND,
         val eventCategoryType: EventCategoryType = EventCategoryType.ALL,
         val isDeleteMode: Boolean = false,
     )
+
+    sealed class RecordSideEffect {
+        data class NavigateToDetail(
+            val eventId: String,
+        ) : RecordSideEffect()
+
+        data object NavigateToAdd : RecordSideEffect()
+    }
 }

--- a/app/src/main/java/com/bongtu/baekseo/presentation/record/RecordScreen.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/record/RecordScreen.kt
@@ -3,24 +3,32 @@ package com.bongtu.baekseo.presentation.record
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.flowWithLifecycle
 import com.bongtu.baekseo.core.common.state.UiState
 import com.bongtu.baekseo.core.designsystem.theme.BongBaekTheme
 import com.bongtu.baekseo.data.model.RecordEvent
-import com.bongtu.baekseo.presentation.record.RecordContract.RecordState
+import com.bongtu.baekseo.presentation.record.RecordContract.RecordSideEffect.NavigateToAdd
+import com.bongtu.baekseo.presentation.record.RecordContract.RecordSideEffect.NavigateToDetail
+import com.bongtu.baekseo.presentation.record.RecordContract.RecordUiState
 import com.bongtu.baekseo.presentation.record.component.AttendTypeTab
 import com.bongtu.baekseo.presentation.record.component.EventCategoryBar
 import com.bongtu.baekseo.presentation.record.component.RecordEmptyContent
 import com.bongtu.baekseo.presentation.record.component.RecordListContent
 import com.bongtu.baekseo.presentation.record.component.RecordTopBar
-import com.bongtu.baekseo.presentation.record.type.AttendType
+import com.bongtu.baekseo.core.common.type.AttendType
 import com.bongtu.baekseo.presentation.record.type.EventCategoryType
 import java.time.LocalDate
 
@@ -29,13 +37,26 @@ fun RecordRoute(
     setBottomBarVisible: (Boolean) -> Unit,
     navigateToDetail: (String) -> Unit,
     navigateToAdd: () -> Unit,
+    innerPadding: PaddingValues,
+    bottomPadding: Dp,
     modifier: Modifier = Modifier,
     viewModel: RecordViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val lifecycleOwner = LocalLifecycleOwner.current
 
     if (uiState.isDeleteMode) {
         BackHandler { viewModel.updateDeleteModeCancel() }
+    }
+
+    LaunchedEffect(viewModel.sideEffect, lifecycleOwner) {
+        viewModel.sideEffect.flowWithLifecycle(lifecycle = lifecycleOwner.lifecycle)
+            .collect { sideEffect ->
+                when (sideEffect) {
+                    is NavigateToDetail -> navigateToDetail(sideEffect.eventId)
+                    is NavigateToAdd -> navigateToAdd()
+                }
+            }
     }
 
     LaunchedEffect(uiState.isDeleteMode) {
@@ -46,21 +67,30 @@ fun RecordRoute(
 
     RecordScreen(
         uiState = uiState,
-        navigateToDetail = navigateToDetail,
-        navigateToAdd = navigateToAdd,
+        innerPadding = innerPadding,
+        navigateToDetail = viewModel::navigateToDetail,
+        navigateToAdd = viewModel::navigateToAdd,
         onTabClick = viewModel::updateAttendType,
         onCategoryClick = viewModel::updateEventType,
         onEnterDeleteModeClick = viewModel::updateDeleteMode,
         onExitDeleteModeClick = viewModel::updateDeleteModeCancel,
         onDeleteSelectedButtonClick = viewModel::updateSelectedDeleteEventId,
         onDeleteClick = viewModel::fetchSelectedDeleteEventIds,
-        modifier = modifier,
+        modifier = modifier
+            .then(
+                if (uiState.isDeleteMode) {
+                    Modifier
+                } else {
+                    Modifier.padding(bottom = bottomPadding)
+                }
+            ),
     )
 }
 
 @Composable
 private fun RecordScreen(
-    uiState: RecordState,
+    uiState: RecordUiState,
+    innerPadding: PaddingValues,
     navigateToDetail: (String) -> Unit,
     navigateToAdd: () -> Unit,
     onTabClick: (AttendType) -> Unit,
@@ -78,6 +108,13 @@ private fun RecordScreen(
     Column(
         modifier = modifier
             .background(color = BongBaekTheme.colors.gray900)
+            .then(
+                if (uiState.isDeleteMode) {
+                    Modifier.padding(innerPadding)
+                } else {
+                    Modifier.statusBarsPadding()
+                }
+            )
     ) {
         RecordTopBar(
             isDeleteMode = uiState.isDeleteMode,
@@ -131,7 +168,7 @@ private fun RecordScreen(
 private fun RecordDefaultScreenPreview() {
     BongBaekTheme {
         RecordScreen(
-            uiState = RecordState(
+            uiState = RecordUiState(
                 recordLoadState = UiState.Success(
                     listOf(
                         RecordEvent(
@@ -208,6 +245,7 @@ private fun RecordDefaultScreenPreview() {
             onDeleteClick = {},
             navigateToDetail = {},
             navigateToAdd = {},
+            innerPadding = PaddingValues(),
             modifier = Modifier,
         )
     }

--- a/app/src/main/java/com/bongtu/baekseo/presentation/record/RecordScreen.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/record/RecordScreen.kt
@@ -38,12 +38,12 @@ fun RecordRoute(
     navigateToDetail: (String) -> Unit,
     navigateToAdd: () -> Unit,
     innerPadding: PaddingValues,
-    bottomPadding: Dp,
     modifier: Modifier = Modifier,
     viewModel: RecordViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val lifecycleOwner = LocalLifecycleOwner.current
+    val bottomPadding = innerPadding.calculateBottomPadding()
 
     if (uiState.isDeleteMode) {
         BackHandler { viewModel.updateDeleteModeCancel() }

--- a/app/src/main/java/com/bongtu/baekseo/presentation/record/RecordScreen.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/record/RecordScreen.kt
@@ -18,6 +18,7 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
 import com.bongtu.baekseo.core.common.state.UiState
+import com.bongtu.baekseo.core.common.type.AttendType
 import com.bongtu.baekseo.core.designsystem.theme.BongBaekTheme
 import com.bongtu.baekseo.data.model.RecordEvent
 import com.bongtu.baekseo.presentation.record.RecordContract.RecordSideEffect.NavigateToAdd
@@ -28,7 +29,6 @@ import com.bongtu.baekseo.presentation.record.component.EventCategoryBar
 import com.bongtu.baekseo.presentation.record.component.RecordEmptyContent
 import com.bongtu.baekseo.presentation.record.component.RecordListContent
 import com.bongtu.baekseo.presentation.record.component.RecordTopBar
-import com.bongtu.baekseo.core.common.type.AttendType
 import com.bongtu.baekseo.presentation.record.type.EventCategoryType
 import java.time.LocalDate
 
@@ -63,15 +63,15 @@ fun RecordRoute(
         setBottomBarVisible(!uiState.isDeleteMode)
     }
 
-    LaunchedEffect(Unit) { viewModel.fetchRecordEvent(EventCategoryType.ALL) }
+    LaunchedEffect(Unit) { viewModel.fetchRecordEvent() }
 
     RecordScreen(
         uiState = uiState,
         innerPadding = innerPadding,
         navigateToDetail = viewModel::navigateToDetail,
         navigateToAdd = viewModel::navigateToAdd,
-        onTabClick = viewModel::updateAttendType,
-        onCategoryClick = viewModel::fetchRecordEvent,
+        onTabClick = viewModel::selectAttendType,
+        onCategoryClick = viewModel::selectEventCategory,
         onEnterDeleteModeClick = viewModel::updateDeleteMode,
         onExitDeleteModeClick = viewModel::updateDeleteModeCancel,
         onDeleteSelectedButtonClick = viewModel::updateSelectedDeleteEventId,

--- a/app/src/main/java/com/bongtu/baekseo/presentation/record/RecordScreen.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/record/RecordScreen.kt
@@ -63,7 +63,7 @@ fun RecordRoute(
         setBottomBarVisible(!uiState.isDeleteMode)
     }
 
-    LaunchedEffect(Unit) { viewModel.fetchRecordEvent() }
+    LaunchedEffect(Unit) { viewModel.fetchRecordEvent(EventCategoryType.ALL) }
 
     RecordScreen(
         uiState = uiState,
@@ -71,7 +71,7 @@ fun RecordRoute(
         navigateToDetail = viewModel::navigateToDetail,
         navigateToAdd = viewModel::navigateToAdd,
         onTabClick = viewModel::updateAttendType,
-        onCategoryClick = viewModel::updateEventType,
+        onCategoryClick = viewModel::fetchRecordEvent,
         onEnterDeleteModeClick = viewModel::updateDeleteMode,
         onExitDeleteModeClick = viewModel::updateDeleteModeCancel,
         onDeleteSelectedButtonClick = viewModel::updateSelectedDeleteEventId,

--- a/app/src/main/java/com/bongtu/baekseo/presentation/record/RecordViewModel.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/record/RecordViewModel.kt
@@ -31,11 +31,9 @@ class RecordViewModel @Inject constructor(
 
     private val _page = MutableStateFlow(0)  // TODO: 무한 스크롤 페이지 state
 
-    fun fetchRecordEvent(categoryType: EventCategoryType) {
+    fun fetchRecordEvent() {
         // TODO: categoryType 이 ALL 이면 쿼리 스트링 x
         // TODO("서버 통신 연결")
-        updateEventType(categoryType)
-        updatePage(0)
 
         updateRecordUiState(
             value = UiState.Success(
@@ -128,7 +126,7 @@ class RecordViewModel @Inject constructor(
             )
         }
 
-    fun updateAttendType(newAttendType: AttendType) =
+    private fun updateAttendType(newAttendType: AttendType) =
         _uiState.update { currentState ->
             currentState.copy(
                 attendType = newAttendType,
@@ -172,6 +170,19 @@ class RecordViewModel @Inject constructor(
                 }
             )
         }
+
+    fun selectEventCategory(newCategoryType: EventCategoryType) {
+        updateEventType(newCategoryType)
+        updatePage(0)
+        fetchRecordEvent()
+    }
+
+    fun selectAttendType(newAttendType: AttendType) {
+        updateAttendType(newAttendType)
+        updateEventType(EventCategoryType.ALL)
+        updatePage(0)
+        fetchRecordEvent()
+    }
 
     fun navigateToDetail(eventId: String) = viewModelScope.launch {
         _sideEffect.emit(RecordSideEffect.NavigateToDetail(eventId))

--- a/app/src/main/java/com/bongtu/baekseo/presentation/record/RecordViewModel.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/record/RecordViewModel.kt
@@ -3,11 +3,11 @@ package com.bongtu.baekseo.presentation.record
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.bongtu.baekseo.core.common.state.UiState
+import com.bongtu.baekseo.core.common.type.AttendType
 import com.bongtu.baekseo.data.model.RecordEvent
 import com.bongtu.baekseo.data.repository.DummyRepository
 import com.bongtu.baekseo.presentation.record.RecordContract.RecordSideEffect
 import com.bongtu.baekseo.presentation.record.RecordContract.RecordUiState
-import com.bongtu.baekseo.core.common.type.AttendType
 import com.bongtu.baekseo.presentation.record.type.EventCategoryType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -29,8 +29,14 @@ class RecordViewModel @Inject constructor(
     private val _sideEffect = MutableSharedFlow<RecordSideEffect>()
     val sideEffect = _sideEffect.asSharedFlow()
 
-    fun fetchRecordEvent() {
+    private val _page = MutableStateFlow(0)  // TODO: 무한 스크롤 페이지 state
+
+    fun fetchRecordEvent(categoryType: EventCategoryType) {
+        // TODO: categoryType 이 ALL 이면 쿼리 스트링 x
         // TODO("서버 통신 연결")
+        updateEventType(categoryType)
+        updatePage(0)
+
         updateRecordUiState(
             value = UiState.Success(
                 listOf(
@@ -129,12 +135,17 @@ class RecordViewModel @Inject constructor(
             )
         }
 
-    fun updateEventType(eventCategoryType: EventCategoryType) =
+    private fun updateEventType(eventCategoryType: EventCategoryType) =
         _uiState.update { currentState ->
             currentState.copy(
                 eventCategoryType = eventCategoryType,
             )
         }
+
+    private fun updatePage(newPage: Int) {
+        _page.value = newPage
+    }
+
 
     fun updateDeleteMode() =
         _uiState.update { currentState ->

--- a/app/src/main/java/com/bongtu/baekseo/presentation/record/RecordViewModel.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/record/RecordViewModel.kt
@@ -1,16 +1,21 @@
 package com.bongtu.baekseo.presentation.record
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.bongtu.baekseo.core.common.state.UiState
 import com.bongtu.baekseo.data.model.RecordEvent
 import com.bongtu.baekseo.data.repository.DummyRepository
-import com.bongtu.baekseo.presentation.record.RecordContract.RecordState
-import com.bongtu.baekseo.presentation.record.type.AttendType
+import com.bongtu.baekseo.presentation.record.RecordContract.RecordSideEffect
+import com.bongtu.baekseo.presentation.record.RecordContract.RecordUiState
+import com.bongtu.baekseo.core.common.type.AttendType
 import com.bongtu.baekseo.presentation.record.type.EventCategoryType
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import java.time.LocalDate
 import javax.inject.Inject
 
@@ -18,8 +23,11 @@ import javax.inject.Inject
 class RecordViewModel @Inject constructor(
     private val dummyRepository: DummyRepository,
 ) : ViewModel() {
-    private val _uiState = MutableStateFlow(RecordState())
+    private val _uiState = MutableStateFlow(RecordUiState())
     val uiState = _uiState.asStateFlow()
+
+    private val _sideEffect = MutableSharedFlow<RecordSideEffect>()
+    val sideEffect = _sideEffect.asSharedFlow()
 
     fun fetchRecordEvent() {
         // TODO("서버 통신 연결")
@@ -153,4 +161,12 @@ class RecordViewModel @Inject constructor(
                 }
             )
         }
+
+    fun navigateToDetail(eventId: String) = viewModelScope.launch {
+        _sideEffect.emit(RecordSideEffect.NavigateToDetail(eventId))
+    }
+
+    fun navigateToAdd() = viewModelScope.launch {
+        _sideEffect.emit(RecordSideEffect.NavigateToAdd)
+    }
 }

--- a/app/src/main/java/com/bongtu/baekseo/presentation/record/RecordViewModel.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/record/RecordViewModel.kt
@@ -7,6 +7,8 @@ import com.bongtu.baekseo.core.common.type.AttendType
 import com.bongtu.baekseo.data.model.RecordEvent
 import com.bongtu.baekseo.data.repository.DummyRepository
 import com.bongtu.baekseo.presentation.record.RecordContract.RecordSideEffect
+import com.bongtu.baekseo.presentation.record.RecordContract.RecordSideEffect.NavigateToAdd
+import com.bongtu.baekseo.presentation.record.RecordContract.RecordSideEffect.NavigateToDetail
 import com.bongtu.baekseo.presentation.record.RecordContract.RecordUiState
 import com.bongtu.baekseo.presentation.record.type.EventCategoryType
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -185,10 +187,10 @@ class RecordViewModel @Inject constructor(
     }
 
     fun navigateToDetail(eventId: String) = viewModelScope.launch {
-        _sideEffect.emit(RecordSideEffect.NavigateToDetail(eventId))
+        _sideEffect.emit(NavigateToDetail(eventId))
     }
 
     fun navigateToAdd() = viewModelScope.launch {
-        _sideEffect.emit(RecordSideEffect.NavigateToAdd)
+        _sideEffect.emit(NavigateToAdd)
     }
 }

--- a/app/src/main/java/com/bongtu/baekseo/presentation/record/RecordViewModel.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/record/RecordViewModel.kt
@@ -111,7 +111,7 @@ class RecordViewModel @Inject constructor(
     fun fetchSelectedDeleteEventIds() {
         // TODO("선택된 삭제 처리 추가 예정")
         updateDeleteModeCancel()
-        updateInitSelectedDeleteEventIds()
+        updateSelectedDeleteEventIds(emptySet())
     }
 
     private fun updateRecordUiState(value: UiState<List<RecordEvent>>) =
@@ -121,24 +121,24 @@ class RecordViewModel @Inject constructor(
             )
         }
 
-    private fun updateInitSelectedDeleteEventIds() =
+    private fun updateSelectedDeleteEventIds(newSelectedDeleteEventIds: Set<String>) =
         _uiState.update { currentState ->
             currentState.copy(
-                selectedDeleteEventIds = emptySet(),
+                selectedDeleteEventIds = newSelectedDeleteEventIds,
             )
         }
 
-    fun updateAttendType(attendType: AttendType) =
+    fun updateAttendType(newAttendType: AttendType) =
         _uiState.update { currentState ->
             currentState.copy(
-                attendType = attendType,
+                attendType = newAttendType,
             )
         }
 
-    private fun updateEventType(eventCategoryType: EventCategoryType) =
+    private fun updateEventType(newEventCategoryType: EventCategoryType) =
         _uiState.update { currentState ->
             currentState.copy(
-                eventCategoryType = eventCategoryType,
+                eventCategoryType = newEventCategoryType,
             )
         }
 

--- a/app/src/main/java/com/bongtu/baekseo/presentation/record/component/AttendTypeTab.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/record/component/AttendTypeTab.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.bongtu.baekseo.core.designsystem.theme.BongBaekTheme
 import com.bongtu.baekseo.core.util.noRippleClickable
-import com.bongtu.baekseo.presentation.record.type.AttendType
+import com.bongtu.baekseo.core.common.type.AttendType
 
 @Immutable
 private data class TabStyle(

--- a/app/src/main/java/com/bongtu/baekseo/presentation/record/navigation/RecordNavigation.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/record/navigation/RecordNavigation.kt
@@ -18,7 +18,6 @@ fun NavGraphBuilder.recordGraph(
     navigateToAdd: () -> Unit,
     navigateToDetail: (String) -> Unit,
     innerPadding: PaddingValues,
-    bottomPadding: Dp,
     modifier: Modifier = Modifier,
 ) {
     composable<Record> {
@@ -27,7 +26,6 @@ fun NavGraphBuilder.recordGraph(
             navigateToDetail = navigateToDetail,
             navigateToAdd = navigateToAdd,
             innerPadding = innerPadding,
-            bottomPadding = bottomPadding,
             modifier = modifier,
         )
     }

--- a/app/src/main/java/com/bongtu/baekseo/presentation/record/navigation/RecordNavigation.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/record/navigation/RecordNavigation.kt
@@ -1,6 +1,8 @@
 package com.bongtu.baekseo.presentation.record.navigation
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
@@ -15,6 +17,8 @@ fun NavGraphBuilder.recordGraph(
     setBottomBarVisible: (Boolean) -> Unit,
     navigateToAdd: () -> Unit,
     navigateToDetail: (String) -> Unit,
+    innerPadding: PaddingValues,
+    bottomPadding: Dp,
     modifier: Modifier = Modifier,
 ) {
     composable<Record> {
@@ -22,6 +26,8 @@ fun NavGraphBuilder.recordGraph(
             setBottomBarVisible = setBottomBarVisible,
             navigateToDetail = navigateToDetail,
             navigateToAdd = navigateToAdd,
+            innerPadding = innerPadding,
+            bottomPadding = bottomPadding,
             modifier = modifier,
         )
     }


### PR DESCRIPTION
## Related issue 🛠
- closed #62

## Work Description ✏️
- viewmodel 관련 로직 일부 수정(무한스크롤 페이지)
- sideEffext 적용
- record inner 패딩 적용

## Screenshot 📸

**InnerPadding 적용**

https://github.com/user-attachments/assets/7b904d0e-e4c0-4152-b8fd-022028bce834


## Uncompleted Tasks 😅
- [ ] N/A

## To Reviewers 📢
- 현재 기록하기 정보를 받아올때 참석/불참석 여부와 카테고리 변경시마다 page 가 초기화 되도록 설정되어있습니다.
page 가 카테고리 클릭시에는 이전 카테고리의 페이지와 스크롤 위치가 유지되어야할까요?
- inner padding 적용시에 하나의 screen 에서 삭제 상태에 따라 바텀네브바가 사라지거나 보여야해서 내부적으로 분기 처리하기 위해 screen 까지 받아서 분기 처리해주었습니다.
- attend type 을 common 으로 이동했습니다. 추후 다른 화면에서 사용될 예정입니다.