### PR TITLE
[FEAT/#67] 홈 뷰 API 연동

### DIFF
--- a/app/src/main/java/com/bongtu/baekseo/core/util/StringExt.kt
+++ b/app/src/main/java/com/bongtu/baekseo/core/util/StringExt.kt
@@ -1,9 +1,26 @@
 package com.bongtu.baekseo.core.util
 
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+/**
+ * mmddyyyy -> yyyy-mm-dd
+ */
 fun String.toFormattedDate(): String {
     if (this.length != 8) return ""
     val month = this.substring(0, 2)
     val day = this.substring(2, 4)
     val year = this.substring(4, 8)
     return "$year-$month-$day"
+}
+
+/**
+ * yyyy-mm-dd -> yyyy. mm. dd (day)
+ */
+fun String.toFormattedDateWithDay(): String {
+    val parsedDate = LocalDate.parse(this, DateTimeFormatter.ISO_DATE)
+    val date = parsedDate.format(DateTimeFormatter.ofPattern("yyyy. MM. dd"))
+    val day = parsedDate.dayOfWeek.getDisplayName(java.time.format.TextStyle.SHORT, Locale.KOREAN)
+    return "$date ($day)"
 }

--- a/app/src/main/java/com/bongtu/baekseo/data/datasource/event/EventDataSource.kt
+++ b/app/src/main/java/com/bongtu/baekseo/data/datasource/event/EventDataSource.kt
@@ -1,6 +1,7 @@
 package com.bongtu.baekseo.data.datasource.event
 
 import com.bongtu.baekseo.core.network.model.BaseResponse
+import com.bongtu.baekseo.data.dto.event.FetchHomeEventsResponse
 import com.bongtu.baekseo.data.dto.event.PostEventCostRequest
 import com.bongtu.baekseo.data.dto.event.PostEventInfoRequest
 import com.bongtu.baekseo.data.dto.event.PostEventCostResponse
@@ -13,4 +14,6 @@ interface EventDataSource {
     suspend fun postEventCost(
         request: PostEventCostRequest,
     ): BaseResponse<PostEventCostResponse>
+
+    suspend fun fetchHomeEvents(): BaseResponse<FetchHomeEventsResponse>
 }

--- a/app/src/main/java/com/bongtu/baekseo/data/datasourceimpl/event/EventDataSourceImpl.kt
+++ b/app/src/main/java/com/bongtu/baekseo/data/datasourceimpl/event/EventDataSourceImpl.kt
@@ -16,4 +16,6 @@ class EventDataSourceImpl @Inject constructor(
     override suspend fun postEventCost(
         request: PostEventCostRequest,
     ) = eventService.postEventCost(request)
+
+    override suspend fun fetchHomeEvents() = eventService.fetchHomeEvents()
 }

--- a/app/src/main/java/com/bongtu/baekseo/data/dto/event/FetchHomeEventsResponse.kt
+++ b/app/src/main/java/com/bongtu/baekseo/data/dto/event/FetchHomeEventsResponse.kt
@@ -1,0 +1,54 @@
+package com.bongtu.baekseo.data.dto.event
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FetchHomeEventsResponse(
+    @SerialName("events")
+    val events: List<Event>
+) {
+    @Serializable
+    data class Event(
+        @SerialName("eventId")
+        val eventId: String,
+        @SerialName("hostInfo")
+        val hostInfo: HostInfo,
+        @SerialName("eventInfo")
+        val eventInfo: EventInfo,
+        @SerialName("locationInfo")
+        val locationInfo: LocationInfo,
+    )
+
+    @Serializable
+    data class HostInfo(
+        @SerialName("hostName")
+        val hostName: String,
+        @SerialName("hostNickname")
+        val hostNickname: String,
+    )
+
+    @Serializable
+    data class EventInfo(
+        @SerialName("eventCategory")
+        val eventCategory: String,
+        @SerialName("relationship")
+        val relationship: String,
+        @SerialName("cost")
+        val cost: Int,
+        @SerialName("isAttend")
+        val isAttend: Boolean?,
+        @SerialName("eventDate")
+        val eventDate: String,
+        @SerialName("dDay")
+        val dDay: Int,
+        @SerialName("note")
+        val note: String?,
+    )
+
+    @Serializable
+    data class LocationInfo(
+        @SerialName("location")
+        val location: String,
+    )
+}

--- a/app/src/main/java/com/bongtu/baekseo/data/dto/event/FetchHomeEventsResponse.kt
+++ b/app/src/main/java/com/bongtu/baekseo/data/dto/event/FetchHomeEventsResponse.kt
@@ -13,19 +13,11 @@ data class FetchHomeEventsResponse(
         @SerialName("eventId")
         val eventId: String,
         @SerialName("hostInfo")
-        val hostInfo: HostInfo,
+        val hostInfo: HostInfoDto,
         @SerialName("eventInfo")
         val eventInfo: EventInfo,
         @SerialName("locationInfo")
         val locationInfo: LocationInfo,
-    )
-
-    @Serializable
-    data class HostInfo(
-        @SerialName("hostName")
-        val hostName: String,
-        @SerialName("hostNickname")
-        val hostNickname: String,
     )
 
     @Serializable

--- a/app/src/main/java/com/bongtu/baekseo/data/mapper/EventMapper.kt
+++ b/app/src/main/java/com/bongtu/baekseo/data/mapper/EventMapper.kt
@@ -1,6 +1,7 @@
 package com.bongtu.baekseo.data.mapper
 
 import com.bongtu.baekseo.data.dto.event.EventInfoDto
+import com.bongtu.baekseo.data.dto.event.FetchHomeEventsResponse
 import com.bongtu.baekseo.data.dto.event.HighAccuracyDto
 import com.bongtu.baekseo.data.dto.event.HostInfoDto
 import com.bongtu.baekseo.data.dto.event.LocationInfoDto
@@ -8,6 +9,7 @@ import com.bongtu.baekseo.data.dto.event.PostEventCostResponse
 import com.bongtu.baekseo.data.model.event.Cost
 import com.bongtu.baekseo.data.model.event.Event
 import com.bongtu.baekseo.data.model.event.HighAccuracy
+import com.bongtu.baekseo.data.model.event.HomeEvent
 import com.bongtu.baekseo.data.model.event.Host
 import com.bongtu.baekseo.data.model.event.Location
 
@@ -41,4 +43,16 @@ fun PostEventCostResponse.toModel() = Cost(
     cost = cost,
     min = range.min,
     max = range.max,
+)
+
+fun FetchHomeEventsResponse.Event.toModel() = HomeEvent(
+    eventId = eventId,
+    hostName = hostInfo.hostName,
+    hostNickname = hostInfo.hostNickname,
+    eventCategory = eventInfo.eventCategory,
+    relationship = eventInfo.relationship,
+    cost = eventInfo.cost,
+    eventDate = eventInfo.eventDate,
+    dDay = eventInfo.dDay,
+    location = locationInfo.location,
 )

--- a/app/src/main/java/com/bongtu/baekseo/data/model/event/HomeEvent.kt
+++ b/app/src/main/java/com/bongtu/baekseo/data/model/event/HomeEvent.kt
@@ -1,0 +1,13 @@
+package com.bongtu.baekseo.data.model.event
+
+data class HomeEvent(
+    val eventId: String,
+    val hostName: String,
+    val hostNickname: String,
+    val eventCategory: String,
+    val relationship: String,
+    val cost: Int,
+    val eventDate: String,
+    val dDay: Int,
+    val location: String,
+)

--- a/app/src/main/java/com/bongtu/baekseo/data/repository/event/EventRepository.kt
+++ b/app/src/main/java/com/bongtu/baekseo/data/repository/event/EventRepository.kt
@@ -3,8 +3,10 @@ package com.bongtu.baekseo.data.repository.event
 import com.bongtu.baekseo.data.model.event.Cost
 import com.bongtu.baekseo.data.model.event.Event
 import com.bongtu.baekseo.data.model.event.HighAccuracy
+import com.bongtu.baekseo.data.model.event.HomeEvent
 import com.bongtu.baekseo.data.model.event.Host
 import com.bongtu.baekseo.data.model.event.Location
+import kotlinx.collections.immutable.ImmutableList
 
 interface EventRepository {
     suspend fun postEventInfo(
@@ -19,4 +21,6 @@ interface EventRepository {
         location: Location,
         highAccuracy: HighAccuracy,
     ): Result<Cost>
+
+    suspend fun fetchHomeEvents(): Result<ImmutableList<HomeEvent>>
 }

--- a/app/src/main/java/com/bongtu/baekseo/data/repositoryimpl/event/EventRepositoryImpl.kt
+++ b/app/src/main/java/com/bongtu/baekseo/data/repositoryimpl/event/EventRepositoryImpl.kt
@@ -8,9 +8,12 @@ import com.bongtu.baekseo.data.mapper.toModel
 import com.bongtu.baekseo.data.model.event.Cost
 import com.bongtu.baekseo.data.model.event.Event
 import com.bongtu.baekseo.data.model.event.HighAccuracy
+import com.bongtu.baekseo.data.model.event.HomeEvent
 import com.bongtu.baekseo.data.model.event.Host
 import com.bongtu.baekseo.data.model.event.Location
 import com.bongtu.baekseo.data.repository.event.EventRepository
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 import javax.inject.Inject
 
 class EventRepositoryImpl @Inject constructor(
@@ -48,5 +51,15 @@ class EventRepositoryImpl @Inject constructor(
         )
     }.mapCatching { response ->
         response.data.toModel()
+    }
+
+    override suspend fun fetchHomeEvents(): Result<ImmutableList<HomeEvent>> = runCatching {
+        eventDataSource.fetchHomeEvents()
+    }.mapCatching { response ->
+        response.data.events.map {
+            it.toModel()
+        }.toImmutableList()
+    }.recoverCatching {
+        emptyList<HomeEvent>().toImmutableList()
     }
 }

--- a/app/src/main/java/com/bongtu/baekseo/data/service/event/EventService.kt
+++ b/app/src/main/java/com/bongtu/baekseo/data/service/event/EventService.kt
@@ -1,10 +1,12 @@
 package com.bongtu.baekseo.data.service.event
 
 import com.bongtu.baekseo.core.network.model.BaseResponse
+import com.bongtu.baekseo.data.dto.event.FetchHomeEventsResponse
 import com.bongtu.baekseo.data.dto.event.PostEventCostRequest
 import com.bongtu.baekseo.data.dto.event.PostEventInfoRequest
 import com.bongtu.baekseo.data.dto.event.PostEventCostResponse
 import retrofit2.http.Body
+import retrofit2.http.GET
 import retrofit2.http.POST
 
 interface EventService {
@@ -17,4 +19,7 @@ interface EventService {
     suspend fun postEventCost(
         @Body request: PostEventCostRequest,
     ): BaseResponse<PostEventCostResponse>
+
+    @GET("api/v1/events/home")
+    suspend fun fetchHomeEvents() : BaseResponse<FetchHomeEventsResponse>
 }

--- a/app/src/main/java/com/bongtu/baekseo/presentation/home/HomeContract.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/home/HomeContract.kt
@@ -2,7 +2,7 @@ package com.bongtu.baekseo.presentation.home
 
 import androidx.compose.runtime.Immutable
 import com.bongtu.baekseo.core.common.state.UiState
-import com.bongtu.baekseo.presentation.home.model.HomeEvent
+import com.bongtu.baekseo.data.model.event.HomeEvent
 import kotlinx.collections.immutable.ImmutableList
 
 class HomeContract {

--- a/app/src/main/java/com/bongtu/baekseo/presentation/home/HomeMainScreen.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/home/HomeMainScreen.kt
@@ -37,10 +37,9 @@ import androidx.lifecycle.flowWithLifecycle
 import com.bongtu.baekseo.R.string.home_schedule_more
 import com.bongtu.baekseo.R.string.home_schedule_title
 import com.bongtu.baekseo.core.common.state.UiState
-import com.bongtu.baekseo.core.common.type.EventType
-import com.bongtu.baekseo.core.common.type.RelationType
 import com.bongtu.baekseo.core.designsystem.theme.BongBaekTheme
 import com.bongtu.baekseo.core.util.noRippleClickable
+import com.bongtu.baekseo.data.model.event.HomeEvent
 import com.bongtu.baekseo.presentation.home.HomeContract.HomeSideEffect.NavigateToEdit
 import com.bongtu.baekseo.presentation.home.HomeContract.HomeSideEffect.NavigateToRecommend
 import com.bongtu.baekseo.presentation.home.HomeContract.HomeSideEffect.NavigateToSchedule
@@ -52,13 +51,8 @@ import com.bongtu.baekseo.presentation.home.component.HomeRecommendCard
 import com.bongtu.baekseo.presentation.home.component.HomeScheduleCard
 import com.bongtu.baekseo.presentation.home.component.HomeScheduleEmptyCard
 import com.bongtu.baekseo.presentation.home.component.HomeTopBar
-import com.bongtu.baekseo.presentation.home.model.HomeEvent
-import com.bongtu.baekseo.presentation.home.model.HomeEventInfo
-import com.bongtu.baekseo.presentation.home.model.HomeHostInfo
-import com.bongtu.baekseo.presentation.home.model.HomeLocationInfo
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
-import java.time.LocalDate
 
 @Composable
 fun HomeMainRoute(
@@ -213,19 +207,19 @@ fun HomeMainSuccessScreen(
                     when (items.size) {
                         1 -> {
                             HomePageSingleCard(
-                                hostname = item.hostInfo.hostName,
-                                eventType = item.eventInfo.eventCategory,
-                                daysLeft = item.eventInfo.dDay,
-                                eventDate = item.eventInfo.eventDate,
+                                hostname = item.hostName,
+                                eventType = item.eventCategory,
+                                daysLeft = item.dDay,
+                                eventDate = item.eventDate,
                             )
                         }
 
                         else -> {
                             HomePageMultipleCard(
-                                hostname = item.hostInfo.hostName,
-                                eventType = item.eventInfo.eventCategory,
-                                daysLeft = item.eventInfo.dDay,
-                                eventDate = item.eventInfo.eventDate,
+                                hostname = item.hostName,
+                                eventType = item.eventCategory,
+                                daysLeft = item.dDay,
+                                eventDate = item.eventDate,
                             )
                         }
                     }
@@ -321,52 +315,37 @@ fun HomeMainSuccessScreen(
 private fun HomeMainSuccessScreenPreview() {
     val items = persistentListOf(
         HomeEvent(
-            eventId = "1",
-            hostInfo = HomeHostInfo(
-                hostName = "공승준",
-                hostNickname = "초록승준",
-            ),
-            eventInfo = HomeEventInfo(
-                eventCategory = EventType.WEDDING,
-                relationship = RelationType.FRIEND,
-                cost = 10000,
-                eventDate = LocalDate.of(2025, 2, 11),
-            ),
-            locationInfo = HomeLocationInfo(
-                location = "강남구 테헤란로 강남 웨딩홀"
-            ),
+            eventId = "eventId1",
+            hostName = "헤헤",
+            hostNickname = "초록승준",
+            eventCategory = "생일",
+            relationship = "친구",
+            cost = 10000,
+            eventDate = "2025.02.11",
+            dDay = 1,
+            location = "강남",
         ),
         HomeEvent(
-            eventId = "2",
-            hostInfo = HomeHostInfo(
-                hostName = "김종명",
-                hostNickname = "봉준호",
-            ),
-            eventInfo = HomeEventInfo(
-                eventCategory = EventType.FIRST_BD,
-                relationship = RelationType.NEIGHBOR,
-                cost = 10000,
-                eventDate = LocalDate.of(2025, 2, 11),
-            ),
-            locationInfo = HomeLocationInfo(
-                location = "강남구 테헤란로 강남 웨딩홀"
-            ),
+            eventId = "eventId2",
+            hostName = "헤헤",
+            hostNickname = "초록승준",
+            eventCategory = "생일",
+            relationship = "친구",
+            cost = 10000,
+            eventDate = "2025.02.11",
+            dDay = 1,
+            location = "강남",
         ),
         HomeEvent(
-            eventId = "3",
-            hostInfo = HomeHostInfo(
-                hostName = "김혜정",
-                hostNickname = "메정",
-            ),
-            eventInfo = HomeEventInfo(
-                eventCategory = EventType.BIRTHDAY,
-                relationship = RelationType.ALUMNI,
-                cost = 10000,
-                eventDate = LocalDate.of(2025, 2, 11),
-            ),
-            locationInfo = HomeLocationInfo(
-                location = "강남구 테헤란로 강남 웨딩홀"
-            ),
+            eventId = "eventId3",
+            hostName = "헤헤",
+            hostNickname = "초록승준",
+            eventCategory = "생일",
+            relationship = "친구",
+            cost = 10000,
+            eventDate = "2025.02.11",
+            dDay = 1,
+            location = "강남",
         ),
     )
 

--- a/app/src/main/java/com/bongtu/baekseo/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/home/HomeViewModel.kt
@@ -3,30 +3,24 @@ package com.bongtu.baekseo.presentation.home
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.bongtu.baekseo.core.common.state.UiState
-import com.bongtu.baekseo.core.common.type.EventType
-import com.bongtu.baekseo.core.common.type.RelationType
 import com.bongtu.baekseo.core.local.datastore.UsernameDataStore
+import com.bongtu.baekseo.data.model.event.HomeEvent
+import com.bongtu.baekseo.data.repository.event.EventRepository
 import com.bongtu.baekseo.presentation.home.HomeContract.HomeSideEffect
 import com.bongtu.baekseo.presentation.home.HomeContract.HomeState
-import com.bongtu.baekseo.presentation.home.model.HomeEvent
-import com.bongtu.baekseo.presentation.home.model.HomeEventInfo
-import com.bongtu.baekseo.presentation.home.model.HomeHostInfo
-import com.bongtu.baekseo.presentation.home.model.HomeLocationInfo
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import java.time.LocalDate
 import javax.inject.Inject
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
-    // TODO: Repository 주입
+    private val eventRepository: EventRepository,
     private val usernameDataStore: UsernameDataStore,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(HomeState())
@@ -36,63 +30,17 @@ class HomeViewModel @Inject constructor(
     val sideEffect = _sideEffect.asSharedFlow()
 
     fun fetchHomeEvent() {
-        // TODO: API 연동
-        updateHomeUiState(
-            value = UiState.Success(
-                persistentListOf(
-                    HomeEvent(
-                        eventId = "1",
-                        hostInfo = HomeHostInfo(
-                            hostName = "공승준",
-                            hostNickname = "초록승준",
-                        ),
-                        eventInfo = HomeEventInfo(
-                            eventCategory = EventType.WEDDING,
-                            relationship = RelationType.FRIEND,
-                            cost = 10000,
-                            eventDate = LocalDate.of(2025, 2, 11),
-                            dDay = 11,
-                        ),
-                        locationInfo = HomeLocationInfo(
-                            location = "강남구 테헤란로 강남 웨딩홀"
-                        ),
-                    ),
-                    HomeEvent(
-                        eventId = "2",
-                        hostInfo = HomeHostInfo(
-                            hostName = "김종명",
-                            hostNickname = "봉준호",
-                        ),
-                        eventInfo = HomeEventInfo(
-                            eventCategory = EventType.FIRST_BD,
-                            relationship = RelationType.NEIGHBOR,
-                            cost = 10000,
-                            eventDate = LocalDate.of(2025, 2, 11),
-                            dDay = 1,
-                        ),
-                        locationInfo = HomeLocationInfo(
-                            location = "강남구 테헤란로 강남 웨딩홀"
-                        ),
-                    ),
-                    HomeEvent(
-                        eventId = "3",
-                        hostInfo = HomeHostInfo(
-                            hostName = "김헤정",
-                            hostNickname = "메정",
-                        ),
-                        eventInfo = HomeEventInfo(
-                            eventCategory = EventType.BIRTHDAY,
-                            relationship = RelationType.ALUMNI,
-                            cost = 10000,
-                            eventDate = LocalDate.of(2025, 2, 11),
-                        ),
-                        locationInfo = HomeLocationInfo(
-                            location = "강남구 테헤란로 강남 웨딩홀"
-                        ),
-                    ),
-                )
-            )
-        )
+        viewModelScope.launch {
+            eventRepository.fetchHomeEvents()
+                .onSuccess { response ->
+                    updateHomeUiState(
+                        value = UiState.Success(response)
+                    )
+                }
+                .onFailure {
+                    // TODO: 추후 처리
+                }
+        }
     }
 
     private fun updateHomeUiState(value: UiState<ImmutableList<HomeEvent>>) {

--- a/app/src/main/java/com/bongtu/baekseo/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/home/HomeViewModel.kt
@@ -38,7 +38,7 @@ class HomeViewModel @Inject constructor(
                     )
                 }
                 .onFailure {
-                    // TODO: 추후 처리
+                    updateHomeUiState(UiState.Failure(it.message ?: "Unknown Error"))
                 }
         }
     }

--- a/app/src/main/java/com/bongtu/baekseo/presentation/home/component/HomePageCard.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/home/component/HomePageCard.kt
@@ -32,15 +32,12 @@ import com.bongtu.baekseo.R.drawable.img_black_alarm
 import com.bongtu.baekseo.R.drawable.img_home_card_multiple
 import com.bongtu.baekseo.R.drawable.img_home_card_single
 import com.bongtu.baekseo.R.string.badge_schedule_empty
-import com.bongtu.baekseo.R.string.home_card_date
 import com.bongtu.baekseo.R.string.home_page_card_description
 import com.bongtu.baekseo.R.string.home_page_card_empty
 import com.bongtu.baekseo.R.string.home_page_card_title
-import com.bongtu.baekseo.core.common.type.EventType
 import com.bongtu.baekseo.core.designsystem.component.badge.BongBaekMediumBadge
 import com.bongtu.baekseo.core.designsystem.theme.BongBaekTheme
 import com.bongtu.baekseo.core.util.toFormattedDateWithDay
-import java.time.LocalDate
 
 private const val SINGLE_RATIO = 320 / 250f
 private const val MULTIPLE_RATIO = 308 / 250f
@@ -50,17 +47,14 @@ private const val POSTPOSITION_E = "이"
 @Composable
 fun HomePageSingleCard(
     hostname: String,
-    eventType: EventType,
-    eventDate: LocalDate,
+    eventType: String,
+    eventDate: String,
     daysLeft: Int,
     modifier: Modifier = Modifier,
 ) {
-    val (date, weekDay) = eventDate.toFormattedDateWithDay()
+    val date = eventDate.toFormattedDateWithDay()
     val postposition = remember(eventType) {
-        when (eventType) {
-            EventType.FIRST_BD -> POSTPOSITION_GA
-            else -> POSTPOSITION_E
-        }
+        if (eventType == "돌잔치") POSTPOSITION_GA else POSTPOSITION_E
     }
 
     Box(
@@ -85,7 +79,7 @@ fun HomePageSingleCard(
                 text = stringResource(
                     home_page_card_title,
                     hostname,
-                    eventType.label,
+                    eventType,
                     postposition,
                     daysLeft
                 ),
@@ -103,7 +97,7 @@ fun HomePageSingleCard(
         }
 
         HomePageCardDate(
-            date = stringResource(home_card_date, date, weekDay),
+            date = date,
             modifier = Modifier
                 .align(Alignment.BottomStart)
                 .padding(
@@ -117,17 +111,14 @@ fun HomePageSingleCard(
 @Composable
 fun HomePageMultipleCard(
     hostname: String,
-    eventType: EventType,
-    eventDate: LocalDate,
+    eventType: String,
+    eventDate: String,
     daysLeft: Int,
     modifier: Modifier = Modifier,
 ) {
-    val (date, weekDay) = eventDate.toFormattedDateWithDay()
+    val date = eventDate.toFormattedDateWithDay()
     val postposition = remember(eventType) {
-        when (eventType) {
-            EventType.FIRST_BD -> POSTPOSITION_GA
-            else -> POSTPOSITION_E
-        }
+        if (eventType == "돌잔치") POSTPOSITION_GA else POSTPOSITION_E
     }
 
     Box(
@@ -152,7 +143,7 @@ fun HomePageMultipleCard(
                 text = stringResource(
                     home_page_card_title,
                     hostname,
-                    eventType.label,
+                    eventType,
                     postposition,
                     daysLeft
                 ),
@@ -170,7 +161,7 @@ fun HomePageMultipleCard(
         }
 
         HomePageCardDate(
-            date = stringResource(home_card_date, date, weekDay),
+            date = date,
             modifier = Modifier
                 .align(Alignment.BottomStart)
                 .padding(
@@ -275,16 +266,16 @@ private fun HomePageCardPreview() {
         ) {
             HomePageSingleCard(
                 hostname = "헤헤",
-                eventType = EventType.WEDDING,
+                eventType = "생일",
                 daysLeft = 10,
-                eventDate = LocalDate.of(2025, 2, 11),
+                eventDate = "2025.02.11 (목)",
             )
 
             HomePageMultipleCard(
                 hostname = "헤헤",
-                eventType = EventType.FIRST_BD,
+                eventType = "생일",
                 daysLeft = 10,
-                eventDate = LocalDate.of(2025, 2, 11),
+                eventDate = "2025.02.11 (목)",
             )
         }
     }

--- a/app/src/main/java/com/bongtu/baekseo/presentation/home/component/HomeScheduleCard.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/home/component/HomeScheduleCard.kt
@@ -22,26 +22,19 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.bongtu.baekseo.R.drawable.ic_calendar
 import com.bongtu.baekseo.R.drawable.ic_location
-import com.bongtu.baekseo.R.string.home_card_date
 import com.bongtu.baekseo.R.string.record_card_cost
-import com.bongtu.baekseo.core.common.type.EventType
-import com.bongtu.baekseo.core.common.type.RelationType
 import com.bongtu.baekseo.core.designsystem.component.badge.BongBaekSmallBadge
 import com.bongtu.baekseo.core.designsystem.theme.BongBaekTheme
 import com.bongtu.baekseo.core.util.toFormattedDateWithDay
-import com.bongtu.baekseo.presentation.home.model.HomeEvent
-import com.bongtu.baekseo.presentation.home.model.HomeEventInfo
-import com.bongtu.baekseo.presentation.home.model.HomeHostInfo
-import com.bongtu.baekseo.presentation.home.model.HomeLocationInfo
+import com.bongtu.baekseo.data.model.event.HomeEvent
 import com.bongtu.baekseo.presentation.home.type.HomeScheduleCardInfoType
-import java.time.LocalDate
 
 @Composable
 fun HomeScheduleCard(
     event: HomeEvent,
     modifier: Modifier = Modifier,
 ) {
-    val (date, weekDay) = event.eventInfo.eventDate.toFormattedDateWithDay()
+    val date = event.eventDate.toFormattedDateWithDay()
 
     Column(
         modifier = modifier
@@ -56,7 +49,7 @@ fun HomeScheduleCard(
             ),
     ) {
         Text(
-            text = event.hostInfo.hostNickname,
+            text = event.hostNickname,
             style = BongBaekTheme.typography.captionRegular12,
             color = BongBaekTheme.colors.primaryNormal,
         )
@@ -66,13 +59,13 @@ fun HomeScheduleCard(
             horizontalArrangement = Arrangement.SpaceBetween,
         ) {
             Text(
-                text = event.hostInfo.hostName,
+                text = event.hostName,
                 style = BongBaekTheme.typography.titleSemiBold18,
                 color = BongBaekTheme.colors.white,
             )
 
             Text(
-                text = stringResource(record_card_cost, event.eventInfo.cost),
+                text = stringResource(record_card_cost, event.cost),
                 style = BongBaekTheme.typography.titleSemiBold18,
                 color = BongBaekTheme.colors.white,
             )
@@ -85,11 +78,11 @@ fun HomeScheduleCard(
             horizontalArrangement = Arrangement.spacedBy(4.dp),
         ) {
             BongBaekSmallBadge(
-                title = event.eventInfo.eventCategory.label,
+                title = event.eventCategory,
             )
 
             BongBaekSmallBadge(
-                title = event.eventInfo.relationship.label,
+                title = event.relationship,
             )
         }
 
@@ -97,14 +90,14 @@ fun HomeScheduleCard(
 
         HomeScheduleCardInfo(
             infoType = HomeScheduleCardInfoType.LOCATION,
-            content = event.locationInfo.location,
+            content = event.location,
         )
 
         Spacer(modifier = Modifier.height(4.dp))
 
         HomeScheduleCardInfo(
             infoType = HomeScheduleCardInfoType.DATE,
-            content = stringResource(home_card_date, date, weekDay),
+            content = date,
         )
     }
 }
@@ -169,19 +162,14 @@ private fun HomeScheduleCardPreview() {
         HomeScheduleCard(
             event = HomeEvent(
                 eventId = "eventId",
-                hostInfo = HomeHostInfo(
-                    hostName = "헤헤",
-                    hostNickname = "헤헤헤",
-                ),
-                eventInfo = HomeEventInfo(
-                    eventCategory = EventType.BIRTHDAY,
-                    relationship = RelationType.FRIEND,
-                    cost = 10000,
-                    eventDate = LocalDate.of(2025, 2, 11),
-                ),
-                locationInfo = HomeLocationInfo(
-                    location = "강남구 테헤란로 강남 웨딩홀"
-                )
+                hostName = "헤헤",
+                hostNickname = "초록승준",
+                eventCategory = "생일",
+                relationship = "친구",
+                cost = 10000,
+                eventDate = "2025.02.11",
+                dDay = 1,
+                location = "강남",
             )
         )
     }


### PR DESCRIPTION
## Related issue 🛠
- closed #67 

## Work Description ✏️
- 경조사 홈 조회 API를 연동했습니다

## Screenshot 📸
| View| Screenshot |
|------|------|
| Home API Response | <img src="https://github.com/user-attachments/assets/a7fd3421-cc2a-413c-8c3b-df0aca213366" width="360"/> |
| Home API Connection 1 | <img src="https://github.com/user-attachments/assets/debf67e1-07c5-47f3-814c-4fac88ff8a66" width="360"/> |
| Home API Connection 1 | <img src="https://github.com/user-attachments/assets/1e059fb2-cb30-4051-80ea-48a177314357" width="360"/> |

## Uncompleted Tasks 😅
- [ ] N/A

## To Reviewers 📢
- 홈은.. 거의 완성!
- 홈에서 UiState가 Success여야 화면을 불러오도록 코드가 작성되어있는데 서버 값 불러오기 전까지 약간 어색해서 로딩 화면이 있으면 좋지 않을까 하는 생각이 있습니다! 이건 나중에 반영해도 될 것 같아요