### PR TITLE
[REFACTOR/#125] 로그인 Process Phoenix 수정

### DIFF
--- a/app/src/main/java/com/bongtu/baekseo/data/repositoryimpl/auth/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/bongtu/baekseo/data/repositoryimpl/auth/AuthRepositoryImpl.kt
@@ -50,10 +50,19 @@ class AuthRepositoryImpl @Inject constructor(
                     refreshToken = refreshToken,
                 )
             )
-            if (response.success || response.status == 200) {
+            if (response.success || response.status == 200)
                 response.data.toModel()
-            } else {
+            else
                 throw IllegalStateException("토큰 재발급 실패: ${response.status} ${response.message}")
+        }.recoverCatching { error ->
+            if (error is retrofit2.HttpException) {
+                val code = error.code()
+                if (code == 401 || code == 404) {
+                    throw IllegalStateException("리프레시 토큰이 유효하지 않거나 만료되었습니다.")
+                }
+                throw IllegalStateException("토큰 재발급 실패: $code", error)
+            } else {
+                throw error
             }
         }
 }

--- a/app/src/main/java/com/bongtu/baekseo/domain/usecase/auth/CheckAutoLoginUseCase.kt
+++ b/app/src/main/java/com/bongtu/baekseo/domain/usecase/auth/CheckAutoLoginUseCase.kt
@@ -2,6 +2,7 @@ package com.bongtu.baekseo.domain.usecase.auth
 
 import com.bongtu.baekseo.core.local.datastore.TokenDataStore
 import com.bongtu.baekseo.data.repository.auth.AuthRepository
+import timber.log.Timber
 import javax.inject.Inject
 
 class CheckAutoLoginUseCase @Inject constructor(
@@ -10,14 +11,14 @@ class CheckAutoLoginUseCase @Inject constructor(
 ) {
     suspend operator fun invoke(): Result<Unit> = runCatching {
         val refreshToken =
-            tokenDataStore.getRefreshToken() ?: throw IllegalStateException("refreshToken 없음")
+            tokenDataStore.getRefreshToken() ?: throw NoSuchElementException("refreshToken 없음")
 
         authRepository.postTokenReissue(refreshToken).onSuccess { response ->
             tokenDataStore.setTokens(response.accessToken, response.refreshToken)
         }.onFailure { error ->
-            val message = error.message.orEmpty()
-            if (message.contains("401") || message.contains("404"))
+            if (error is IllegalStateException) {
                 tokenDataStore.clearInfo()
+            }
             throw error
         }
     }

--- a/app/src/main/java/com/bongtu/baekseo/domain/usecase/auth/CheckAutoLoginUseCase.kt
+++ b/app/src/main/java/com/bongtu/baekseo/domain/usecase/auth/CheckAutoLoginUseCase.kt
@@ -15,6 +15,7 @@ class CheckAutoLoginUseCase @Inject constructor(
         authRepository.postTokenReissue(refreshToken).onSuccess { response ->
             tokenDataStore.setTokens(response.accessToken, response.refreshToken)
         }.onFailure { error ->
+            tokenDataStore.clearInfo()
             throw error
         }
     }

--- a/app/src/main/java/com/bongtu/baekseo/domain/usecase/auth/CheckAutoLoginUseCase.kt
+++ b/app/src/main/java/com/bongtu/baekseo/domain/usecase/auth/CheckAutoLoginUseCase.kt
@@ -2,7 +2,6 @@ package com.bongtu.baekseo.domain.usecase.auth
 
 import com.bongtu.baekseo.core.local.datastore.TokenDataStore
 import com.bongtu.baekseo.data.repository.auth.AuthRepository
-import timber.log.Timber
 import javax.inject.Inject
 
 class CheckAutoLoginUseCase @Inject constructor(

--- a/app/src/main/java/com/bongtu/baekseo/domain/usecase/auth/CheckAutoLoginUseCase.kt
+++ b/app/src/main/java/com/bongtu/baekseo/domain/usecase/auth/CheckAutoLoginUseCase.kt
@@ -15,7 +15,9 @@ class CheckAutoLoginUseCase @Inject constructor(
         authRepository.postTokenReissue(refreshToken).onSuccess { response ->
             tokenDataStore.setTokens(response.accessToken, response.refreshToken)
         }.onFailure { error ->
-            tokenDataStore.clearInfo()
+            val message = error.message.orEmpty()
+            if (message.contains("401") || message.contains("404"))
+                tokenDataStore.clearInfo()
             throw error
         }
     }

--- a/app/src/main/java/com/bongtu/baekseo/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/main/MainActivity.kt
@@ -1,5 +1,7 @@
 package com.bongtu.baekseo.presentation.main
 
+import android.content.Context
+import android.content.Intent
 import android.graphics.Color
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -7,20 +9,39 @@ import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import com.bongtu.baekseo.core.designsystem.theme.BongBaekTheme
+import com.jakewharton.processphoenix.ProcessPhoenix
 import dagger.hilt.android.AndroidEntryPoint
+
+const val IS_START_ONBOARDING = "is_start_onBoarding"
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        val isStartOnBoarding = intent.getBooleanExtra(IS_START_ONBOARDING, false)
+
         enableEdgeToEdge(
             statusBarStyle = SystemBarStyle.dark(Color.TRANSPARENT),
         )
         window.isNavigationBarContrastEnforced = false
         setContent {
             BongBaekTheme {
-                MainScreen()
+                MainScreen(
+                    isStartOnBoarding = isStartOnBoarding,
+                    onRestartApp = {
+                        restartApp(this, it)
+                    },
+                )
             }
         }
+    }
+
+    private fun restartApp(context: Context, isStartOnBoarding: Boolean) {
+        val intent = Intent(context, this::class.java).apply {
+            putExtra(IS_START_ONBOARDING, isStartOnBoarding)
+            flags = Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK
+        }
+        ProcessPhoenix.triggerRebirth(context, intent)
     }
 }

--- a/app/src/main/java/com/bongtu/baekseo/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/main/MainActivity.kt
@@ -12,7 +12,7 @@ import com.bongtu.baekseo.core.designsystem.theme.BongBaekTheme
 import com.jakewharton.processphoenix.ProcessPhoenix
 import dagger.hilt.android.AndroidEntryPoint
 
-const val IS_START_ONBOARDING = "is_start_onBoarding"
+private const val IS_START_ONBOARDING = "is_start_onBoarding"
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {

--- a/app/src/main/java/com/bongtu/baekseo/presentation/main/MainNavigator.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/main/MainNavigator.kt
@@ -7,7 +7,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.navigation.NavDestination
 import androidx.navigation.NavDestination.Companion.hasRoute
-import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
@@ -15,7 +14,6 @@ import androidx.navigation.navOptions
 import com.bongtu.baekseo.presentation.home.navigation.navigateToHome
 import com.bongtu.baekseo.presentation.recommend.navigation.navigateToRecommend
 import com.bongtu.baekseo.presentation.record.navigation.navigateToRecord
-import com.bongtu.baekseo.presentation.splash.navigation.Splash
 
 class MainNavigator(
     val navController: NavHostController,
@@ -23,8 +21,6 @@ class MainNavigator(
     private val currentDestination: NavDestination?
         @Composable get() = navController
             .currentBackStackEntryAsState().value?.destination
-
-    val startDestination = Splash
 
     val currentTab: MainTab?
         @Composable get() = MainTab.find { tab ->

--- a/app/src/main/java/com/bongtu/baekseo/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/main/MainScreen.kt
@@ -42,13 +42,6 @@ import kotlinx.collections.immutable.toImmutableList
 fun MainScreen(
     navigator: MainNavigator = rememberMainNavigator(),
 ) {
-    val activity = LocalActivity.current as Activity
-    val startOnboarding = remember {
-        activity.intent.getBooleanExtra("startDestination", false)
-    }
-
-    val startDestination = if (startOnboarding) OnBoarding else Splash
-
     Scaffold(
         bottomBar = {
             MainBottomBar(
@@ -65,7 +58,6 @@ fun MainScreen(
         MainNavHost(
             navigator = navigator,
             innerPadding = innerPadding,
-            startDestination = startDestination,
             modifier = Modifier,
         )
     }
@@ -75,9 +67,15 @@ fun MainScreen(
 private fun MainNavHost(
     navigator: MainNavigator,
     innerPadding: PaddingValues,
-    startDestination: Any,
     modifier: Modifier = Modifier,
 ) {
+    val activity = LocalActivity.current as Activity
+    val startOnboarding = remember {
+        activity.intent.getBooleanExtra("startDestination", false)
+    }
+
+    val startDestination = if (startOnboarding) OnBoarding else Splash
+
     NavHost(
         enterTransition = { EnterTransition.None },
         exitTransition = { ExitTransition.None },

--- a/app/src/main/java/com/bongtu/baekseo/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/main/MainScreen.kt
@@ -1,7 +1,5 @@
 package com.bongtu.baekseo.presentation.main
 
-import android.app.Activity
-import androidx.activity.compose.LocalActivity
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.foundation.background
@@ -9,7 +7,6 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
 import androidx.navigation.navOptions
@@ -40,6 +37,8 @@ import kotlinx.collections.immutable.toImmutableList
 
 @Composable
 fun MainScreen(
+    isStartOnBoarding: Boolean,
+    onRestartApp: (Boolean) -> Unit,
     navigator: MainNavigator = rememberMainNavigator(),
 ) {
     Scaffold(
@@ -56,6 +55,8 @@ fun MainScreen(
             .background(BongBaekTheme.colors.gray900),
     ) { innerPadding ->
         MainNavHost(
+            isStartOnBoarding = isStartOnBoarding,
+            onRestartApp = onRestartApp,
             navigator = navigator,
             innerPadding = innerPadding,
             modifier = Modifier,
@@ -65,16 +66,13 @@ fun MainScreen(
 
 @Composable
 private fun MainNavHost(
+    isStartOnBoarding: Boolean,
+    onRestartApp: (Boolean) -> Unit,
     navigator: MainNavigator,
     innerPadding: PaddingValues,
     modifier: Modifier = Modifier,
 ) {
-    val activity = LocalActivity.current as Activity
-    val startOnboarding = remember {
-        activity.intent.getBooleanExtra("startDestination", false)
-    }
-
-    val startDestination = if (startOnboarding) OnBoarding else Splash
+    val startDestination = if (isStartOnBoarding) OnBoarding else Splash
 
     NavHost(
         enterTransition = { EnterTransition.None },
@@ -85,6 +83,7 @@ private fun MainNavHost(
         startDestination = startDestination,
     ) {
         splashGraph(
+            onRestartApp = onRestartApp,
             navigateToOnBoarding = {
                 navigator.navController.navigateToOnBoarding(
                     navOptions = navOptions {

--- a/app/src/main/java/com/bongtu/baekseo/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/main/MainScreen.kt
@@ -1,5 +1,7 @@
 package com.bongtu.baekseo.presentation.main
 
+import android.app.Activity
+import androidx.activity.compose.LocalActivity
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.foundation.background
@@ -7,6 +9,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
 import androidx.navigation.navOptions
@@ -39,6 +42,13 @@ import kotlinx.collections.immutable.toImmutableList
 fun MainScreen(
     navigator: MainNavigator = rememberMainNavigator(),
 ) {
+    val activity = LocalActivity.current as Activity
+    val startOnboarding = remember {
+        activity.intent.getBooleanExtra("startDestination", false)
+    }
+
+    val startDestination = if (startOnboarding) OnBoarding else Splash
+
     Scaffold(
         bottomBar = {
             MainBottomBar(
@@ -55,6 +65,7 @@ fun MainScreen(
         MainNavHost(
             navigator = navigator,
             innerPadding = innerPadding,
+            startDestination = startDestination,
             modifier = Modifier,
         )
     }
@@ -64,6 +75,7 @@ fun MainScreen(
 private fun MainNavHost(
     navigator: MainNavigator,
     innerPadding: PaddingValues,
+    startDestination: Any,
     modifier: Modifier = Modifier,
 ) {
     NavHost(
@@ -72,7 +84,7 @@ private fun MainNavHost(
         popEnterTransition = { EnterTransition.None },
         popExitTransition = { ExitTransition.None },
         navController = navigator.navController,
-        startDestination = navigator.startDestination,
+        startDestination = startDestination,
     ) {
         splashGraph(
             navigateToOnBoarding = {

--- a/app/src/main/java/com/bongtu/baekseo/presentation/onboarding/OnBoardingSettingScreen.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/onboarding/OnBoardingSettingScreen.kt
@@ -1,6 +1,5 @@
 package com.bongtu.baekseo.presentation.onboarding
 
-import android.content.Intent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -52,11 +51,9 @@ import com.bongtu.baekseo.core.designsystem.component.topbar.BongBaekTopBar
 import com.bongtu.baekseo.core.designsystem.theme.BongBaekTheme
 import com.bongtu.baekseo.core.util.DateTextFieldFormat
 import com.bongtu.baekseo.core.util.noRippleClickable
-import com.bongtu.baekseo.presentation.main.MainActivity
 import com.bongtu.baekseo.presentation.onboarding.OnBoardingContract.OnBoardingSideEffect.NavigateToHome
 import com.bongtu.baekseo.presentation.onboarding.component.OnBoardingButton
 import com.bongtu.baekseo.presentation.onboarding.component.OnBoardingSwitch
-import com.jakewharton.processphoenix.ProcessPhoenix
 
 @Composable
 fun OnBoardingSettingScreen(
@@ -199,14 +196,7 @@ fun OnBoardingSettingScreen(
 
             BongBaekButton(
                 title = stringResource(id = button_start_service),
-                onClick = {
-                    viewModel.postSignUp()
-                    val intent = Intent(context, MainActivity::class.java).apply {
-                        putExtra("startDestination", true)
-                        flags = Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK
-                    }
-                    ProcessPhoenix.triggerRebirth(context, intent)
-                },
+                onClick = viewModel::postSignUp,
                 buttonType = ButtonType.PRIMARY,
                 modifier = Modifier
                     .fillMaxWidth()

--- a/app/src/main/java/com/bongtu/baekseo/presentation/onboarding/OnBoardingSettingScreen.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/onboarding/OnBoardingSettingScreen.kt
@@ -1,8 +1,7 @@
 package com.bongtu.baekseo.presentation.onboarding
 
+import android.content.Intent
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.EnterTransition
-import androidx.compose.animation.ExitTransition
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -53,6 +52,7 @@ import com.bongtu.baekseo.core.designsystem.component.topbar.BongBaekTopBar
 import com.bongtu.baekseo.core.designsystem.theme.BongBaekTheme
 import com.bongtu.baekseo.core.util.DateTextFieldFormat
 import com.bongtu.baekseo.core.util.noRippleClickable
+import com.bongtu.baekseo.presentation.main.MainActivity
 import com.bongtu.baekseo.presentation.onboarding.OnBoardingContract.OnBoardingSideEffect.NavigateToHome
 import com.bongtu.baekseo.presentation.onboarding.component.OnBoardingButton
 import com.bongtu.baekseo.presentation.onboarding.component.OnBoardingSwitch
@@ -201,7 +201,11 @@ fun OnBoardingSettingScreen(
                 title = stringResource(id = button_start_service),
                 onClick = {
                     viewModel.postSignUp()
-                    ProcessPhoenix.triggerRebirth(context)
+                    val intent = Intent(context, MainActivity::class.java).apply {
+                        putExtra("startDestination", true)
+                        flags = Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK
+                    }
+                    ProcessPhoenix.triggerRebirth(context, intent)
                 },
                 buttonType = ButtonType.PRIMARY,
                 modifier = Modifier

--- a/app/src/main/java/com/bongtu/baekseo/presentation/splash/SplashContract.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/splash/SplashContract.kt
@@ -4,5 +4,6 @@ class SplashContract {
     sealed class SplashSideEffect {
         data object NavigateToHome : SplashSideEffect()
         data object NavigateToOnBoarding : SplashSideEffect()
+        data object RestartApp: SplashSideEffect()
     }
 }

--- a/app/src/main/java/com/bongtu/baekseo/presentation/splash/SplashScreen.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/splash/SplashScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -28,21 +29,23 @@ import com.bongtu.baekseo.R.drawable.ic_splash_name
 import com.bongtu.baekseo.core.designsystem.theme.BongBaekTheme
 import com.bongtu.baekseo.presentation.splash.SplashContract.SplashSideEffect.NavigateToHome
 import com.bongtu.baekseo.presentation.splash.SplashContract.SplashSideEffect.NavigateToOnBoarding
+import com.bongtu.baekseo.presentation.splash.SplashContract.SplashSideEffect.RestartApp
+import com.jakewharton.processphoenix.ProcessPhoenix
 import kotlinx.coroutines.delay
 
 @Composable
 fun SplashRoute(
     navigateToOnBoarding: () -> Unit,
-    navigateToHome: () -> Unit, // TODO: 추후 사용
+    navigateToHome: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: SplashViewModel = hiltViewModel()
 ) {
     val lifecycleOwner = LocalLifecycleOwner.current
+    val context = LocalContext.current
 
     LaunchedEffect(Unit) {
-        viewModel.postTokenReissue()
         delay(1500)
-        navigateToOnBoarding()
+        viewModel.postTokenReissue()
     }
 
     LaunchedEffect(viewModel.sideEffect, lifecycleOwner) {
@@ -51,6 +54,7 @@ fun SplashRoute(
                 when (sideEffect) {
                     is NavigateToHome -> navigateToHome()
                     is NavigateToOnBoarding -> navigateToOnBoarding()
+                    is RestartApp -> ProcessPhoenix.triggerRebirth(context)
                 }
             }
     }

--- a/app/src/main/java/com/bongtu/baekseo/presentation/splash/SplashScreen.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/splash/SplashScreen.kt
@@ -1,6 +1,5 @@
 package com.bongtu.baekseo.presentation.splash
 
-import android.content.Intent
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -17,7 +16,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -28,22 +26,20 @@ import androidx.lifecycle.flowWithLifecycle
 import com.bongtu.baekseo.R.drawable.ic_splash_logo
 import com.bongtu.baekseo.R.drawable.ic_splash_name
 import com.bongtu.baekseo.core.designsystem.theme.BongBaekTheme
-import com.bongtu.baekseo.presentation.main.MainActivity
 import com.bongtu.baekseo.presentation.splash.SplashContract.SplashSideEffect.NavigateToHome
 import com.bongtu.baekseo.presentation.splash.SplashContract.SplashSideEffect.NavigateToOnBoarding
 import com.bongtu.baekseo.presentation.splash.SplashContract.SplashSideEffect.RestartApp
-import com.jakewharton.processphoenix.ProcessPhoenix
 import kotlinx.coroutines.delay
 
 @Composable
 fun SplashRoute(
+    onRestartApp: (Boolean) -> Unit,
     navigateToOnBoarding: () -> Unit,
     navigateToHome: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: SplashViewModel = hiltViewModel()
 ) {
     val lifecycleOwner = LocalLifecycleOwner.current
-    val context = LocalContext.current
 
     LaunchedEffect(Unit) {
         delay(1500)
@@ -56,13 +52,7 @@ fun SplashRoute(
                 when (sideEffect) {
                     is NavigateToHome -> navigateToHome()
                     is NavigateToOnBoarding -> navigateToOnBoarding()
-                    is RestartApp -> {
-                        val intent = Intent(context, MainActivity::class.java).apply {
-                            putExtra("startDestination", true)
-                            flags = Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK
-                        }
-                        ProcessPhoenix.triggerRebirth(context, intent)
-                    }
+                    is RestartApp -> onRestartApp(true)
                 }
             }
     }

--- a/app/src/main/java/com/bongtu/baekseo/presentation/splash/SplashScreen.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/splash/SplashScreen.kt
@@ -1,5 +1,6 @@
 package com.bongtu.baekseo.presentation.splash
 
+import android.content.Intent
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -27,6 +28,7 @@ import androidx.lifecycle.flowWithLifecycle
 import com.bongtu.baekseo.R.drawable.ic_splash_logo
 import com.bongtu.baekseo.R.drawable.ic_splash_name
 import com.bongtu.baekseo.core.designsystem.theme.BongBaekTheme
+import com.bongtu.baekseo.presentation.main.MainActivity
 import com.bongtu.baekseo.presentation.splash.SplashContract.SplashSideEffect.NavigateToHome
 import com.bongtu.baekseo.presentation.splash.SplashContract.SplashSideEffect.NavigateToOnBoarding
 import com.bongtu.baekseo.presentation.splash.SplashContract.SplashSideEffect.RestartApp
@@ -54,7 +56,13 @@ fun SplashRoute(
                 when (sideEffect) {
                     is NavigateToHome -> navigateToHome()
                     is NavigateToOnBoarding -> navigateToOnBoarding()
-                    is RestartApp -> ProcessPhoenix.triggerRebirth(context)
+                    is RestartApp -> {
+                        val intent = Intent(context, MainActivity::class.java).apply {
+                            putExtra("startDestination", true)
+                            flags = Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK
+                        }
+                        ProcessPhoenix.triggerRebirth(context, intent)
+                    }
                 }
             }
     }

--- a/app/src/main/java/com/bongtu/baekseo/presentation/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/splash/SplashViewModel.kt
@@ -6,11 +6,11 @@ import com.bongtu.baekseo.domain.usecase.auth.CheckAutoLoginUseCase
 import com.bongtu.baekseo.presentation.splash.SplashContract.SplashSideEffect
 import com.bongtu.baekseo.presentation.splash.SplashContract.SplashSideEffect.NavigateToHome
 import com.bongtu.baekseo.presentation.splash.SplashContract.SplashSideEffect.NavigateToOnBoarding
+import com.bongtu.baekseo.presentation.splash.SplashContract.SplashSideEffect.RestartApp
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
-import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -26,8 +26,12 @@ class SplashViewModel @Inject constructor(
                 .onSuccess {
                     _sideEffect.emit(NavigateToHome)
                 }.onFailure { error ->
-                    Timber.tag("SplashScreen").e("${error.message}")
-                    _sideEffect.emit(NavigateToOnBoarding)
+                    val message = error.message.orEmpty()
+
+                    if (message.contains("401") || message.contains("404"))
+                        _sideEffect.emit(RestartApp)
+                    else
+                        _sideEffect.emit(NavigateToOnBoarding)
                 }
         }
     }

--- a/app/src/main/java/com/bongtu/baekseo/presentation/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/splash/SplashViewModel.kt
@@ -26,11 +26,9 @@ class SplashViewModel @Inject constructor(
                 .onSuccess {
                     _sideEffect.emit(NavigateToHome)
                 }.onFailure { error ->
-                    val message = error.message.orEmpty()
-
-                    if (message.contains("401") || message.contains("404"))
+                    if (error is IllegalStateException) {
                         _sideEffect.emit(RestartApp)
-                    else
+                    } else
                         _sideEffect.emit(NavigateToOnBoarding)
                 }
         }

--- a/app/src/main/java/com/bongtu/baekseo/presentation/splash/navigation/SplashNavigation.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/splash/navigation/SplashNavigation.kt
@@ -13,12 +13,14 @@ fun NavController.navigateToSplash(navOptions: NavOptions? = null) =
     navigate(Splash, navOptions)
 
 fun NavGraphBuilder.splashGraph(
+    onRestartApp: (Boolean) -> Unit,
     navigateToOnBoarding: () -> Unit,
     navigateToHome: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     composable<Splash> {
         SplashRoute(
+            onRestartApp = onRestartApp,
             navigateToOnBoarding = navigateToOnBoarding,
             navigateToHome = navigateToHome,
             modifier = modifier,


### PR DESCRIPTION
## Related issue 🛠
- closed #125 

## Work Description ✏️
- 로그인 Process Phoenix 수정
   - 토큰이 없을 때, 온보딩으로 이동하도록 변경했습니다.
   - 401이나 404가 떴을 때, 토큰을 지우고 앱을 재시작하게 변경했습니다.
   - 앱을 재시작한 후, 토큰이 없으므로 온보딩으로 이동하는 로직으로 구현하였습니다.
- MainNavigator의 StartDestination을 지우고 MainNavHost에서 제어하고 있습니다.
   - MainActivity에서 앱 재시작을 하는 함수를 만들었습니다.

## Screenshot 📸
- N/A

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
- 401이나 404가 떴을 때 앱을 재시작하며 온보딩이 2번 뜨게 되는데(처음 + 토큰을 지우고 앱 재시작시) 뭔가 어색한 것 같음 + 이 로직이 맞는지 잘 모르겠어서 한 번씩 확인 부탁드립니다ㅜㅜ!
- 종명띠는 천재일까.............. 해결 완