### PR TITLE
[REFACTOR/#157] 서버 api 응답 수정 사항 반영

### DIFF
--- a/app/src/main/java/com/bongtu/baekseo/core/local/datastore/ApiKeyDataStore.kt
+++ b/app/src/main/java/com/bongtu/baekseo/core/local/datastore/ApiKeyDataStore.kt
@@ -1,0 +1,34 @@
+package com.bongtu.baekseo.core.local.datastore
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class ApiKeyDataStore @Inject constructor(
+    private val preferenceDataStore: DataStore<Preferences>,
+) {
+    suspend fun getApiKey(): String = preferenceDataStore.data.map { preferences ->
+        preferences[preferencesApiKey]
+    }.firstOrNull() ?: API_KEY
+
+    suspend fun setApiKey(apiKey: String) {
+        preferenceDataStore.edit { preferences ->
+            preferences[preferencesApiKey] = apiKey
+        }
+    }
+
+    suspend fun clearInfo() {
+        preferenceDataStore.edit { preferences ->
+            preferences.remove(preferencesApiKey)
+        }
+    }
+
+    companion object {
+        private const val API_KEY = "api_key"
+        private val preferencesApiKey = stringPreferencesKey(API_KEY)
+    }
+}

--- a/app/src/main/java/com/bongtu/baekseo/core/local/datastore/DataStoreModule.kt
+++ b/app/src/main/java/com/bongtu/baekseo/core/local/datastore/DataStoreModule.kt
@@ -14,9 +14,11 @@ import javax.inject.Singleton
 object DataStoreModule {
     private const val TOKEN_PREFERENCE_NAME = "token_preference"
     private const val USER_NAME_PREFERENCE_NAME = "user_name_preference"
+    private const val API_KEY_PREFERENCE_NAME = "api_key_preference"
 
     private val Context.provideDataStore by preferencesDataStore(TOKEN_PREFERENCE_NAME)
     private val Context.provideUsernameDataStore by preferencesDataStore(USER_NAME_PREFERENCE_NAME)
+    private val Context.provideApiKeyDataStore by preferencesDataStore(API_KEY_PREFERENCE_NAME)
 
     @Provides
     @Singleton
@@ -29,4 +31,10 @@ object DataStoreModule {
     fun provideUsernameDataStore(
         @ApplicationContext context: Context,
     ) = UsernameDataStore(context.provideUsernameDataStore)
+
+    @Provides
+    @Singleton
+    fun provideApikeyDataStore(
+        @ApplicationContext context: Context,
+    ) = ApiKeyDataStore(context.provideApiKeyDataStore)
 }

--- a/app/src/main/java/com/bongtu/baekseo/core/network/KakaoHeaderInterceptor.kt
+++ b/app/src/main/java/com/bongtu/baekseo/core/network/KakaoHeaderInterceptor.kt
@@ -5,13 +5,19 @@ import android.os.Build.MODEL
 import android.os.Build.VERSION.SDK_INT
 import com.bongtu.baekseo.BuildConfig.APPLICATION_ID
 import com.bongtu.baekseo.BuildConfig.KAKAO_API_KEY
+import com.bongtu.baekseo.core.local.datastore.ApiKeyDataStore
+import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
 import okhttp3.Response
 import java.util.Locale
 import javax.inject.Inject
 
-class KakaoHeaderInterceptor @Inject constructor() : Interceptor {
+class KakaoHeaderInterceptor @Inject constructor(
+    private val apiKeyDataStore: ApiKeyDataStore,
+) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
+        val apiKey = runBlocking { apiKeyDataStore.getApiKey() }
+
         val kaHeaderValue = buildString {
             append("sdk/1.0.0 ")
             append("os/android-$SDK_INT ")
@@ -21,7 +27,7 @@ class KakaoHeaderInterceptor @Inject constructor() : Interceptor {
         }
 
         val newRequest = chain.request().newBuilder()
-            .addHeader("Authorization", "KakaoAK $KAKAO_API_KEY")
+            .addHeader("Authorization", "KakaoAK $apiKey")
             .addHeader("KA", kaHeaderValue)
             .build()
 

--- a/app/src/main/java/com/bongtu/baekseo/core/network/di/NetworkModule.kt
+++ b/app/src/main/java/com/bongtu/baekseo/core/network/di/NetworkModule.kt
@@ -3,6 +3,7 @@ package com.bongtu.baekseo.core.network.di
 import com.bongtu.baekseo.BuildConfig
 import com.bongtu.baekseo.BuildConfig.BASE_URL
 import com.bongtu.baekseo.BuildConfig.KAKAO_BASE_URL
+import com.bongtu.baekseo.core.local.datastore.ApiKeyDataStore
 import com.bongtu.baekseo.core.local.datastore.TokenDataStore
 import com.bongtu.baekseo.core.network.HeaderInterceptor
 import com.bongtu.baekseo.core.network.KakaoHeaderInterceptor
@@ -75,7 +76,9 @@ object NetworkModule {
     @Provides
     @Singleton
     @Kakao
-    fun provideKakaoHeaderInterceptor(): Interceptor = KakaoHeaderInterceptor()
+    fun provideKakaoHeaderInterceptor(
+        apiKeyDataStore: ApiKeyDataStore,
+    ): Interceptor = KakaoHeaderInterceptor(apiKeyDataStore)
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/bongtu/baekseo/data/datasource/event/EventDataSource.kt
+++ b/app/src/main/java/com/bongtu/baekseo/data/datasource/event/EventDataSource.kt
@@ -1,6 +1,7 @@
 package com.bongtu.baekseo.data.datasource.event
 
 import com.bongtu.baekseo.core.network.model.BaseResponse
+import com.bongtu.baekseo.core.network.model.BaseResponseWithoutData
 import com.bongtu.baekseo.data.dto.event.DeleteEventsRequest
 import com.bongtu.baekseo.data.dto.event.GetEventDetailResponse
 import com.bongtu.baekseo.data.dto.event.GetHomeEventsResponse
@@ -13,7 +14,7 @@ import com.bongtu.baekseo.data.dto.event.PutEventInfoRequest
 interface EventDataSource {
     suspend fun postEventInfo(
         request: PostEventInfoRequest,
-    ): BaseResponse<Unit>
+    ): BaseResponseWithoutData
 
     suspend fun postEventCost(
         request: PostEventCostRequest,
@@ -33,11 +34,11 @@ interface EventDataSource {
     suspend fun putEventInfo(
         eventId: String,
         request: PutEventInfoRequest,
-    ): BaseResponse<Unit>
+    ): BaseResponseWithoutData
 
     suspend fun deleteEvents(
         request: DeleteEventsRequest,
-    ): BaseResponse<Unit>
+    ): BaseResponseWithoutData
 
     suspend fun getRecordEvents(
         page: Int,
@@ -47,5 +48,5 @@ interface EventDataSource {
 
     suspend fun deleteEventInfo(
         eventId: String,
-    ): BaseResponse<Unit>
+    ): BaseResponseWithoutData
 }

--- a/app/src/main/java/com/bongtu/baekseo/data/datasourceimpl/auth/AuthDataSourceImpl.kt
+++ b/app/src/main/java/com/bongtu/baekseo/data/datasourceimpl/auth/AuthDataSourceImpl.kt
@@ -14,12 +14,12 @@ import javax.inject.Inject
 class AuthDataSourceImpl @Inject constructor(
     private val authService: AuthService,
 ) : AuthDataSource {
-    override suspend fun postKakaoLogin(request: PostKakaoLoginRequest): BaseResponse<PostKakaoLoginResponse> =
+    override suspend fun postKakaoLogin(request: PostKakaoLoginRequest) =
         authService.postKakaoLogin(request)
 
-    override suspend fun postSignUp(request: PostSignUpRequest): BaseResponse<PostKakaoLoginResponse> =
+    override suspend fun postSignUp(request: PostSignUpRequest) =
         authService.postSignUp(request)
 
-    override suspend fun postTokenReissue(request: PostTokenReissueRequest): BaseResponse<PostTokenReissueResponse> =
+    override suspend fun postTokenReissue(request: PostTokenReissueRequest) =
         authService.postTokenReissue(request)
 }

--- a/app/src/main/java/com/bongtu/baekseo/data/datasourceimpl/event/EventDataSourceImpl.kt
+++ b/app/src/main/java/com/bongtu/baekseo/data/datasourceimpl/event/EventDataSourceImpl.kt
@@ -26,19 +26,19 @@ class EventDataSourceImpl @Inject constructor(
         request: PutEventInfoRequest,
     ) = eventService.putEventInfo(eventId, request)
 
-    override suspend fun deleteEvents(request: DeleteEventsRequest): BaseResponse<Unit> =
-        eventService.deleteEvents(request)
+    override suspend fun deleteEvents(
+        request: DeleteEventsRequest,
+    ) = eventService.deleteEvents(request)
 
     override suspend fun getRecordEvents(
         page: Int,
         attended: Boolean,
         category: String?,
-    ): BaseResponse<GetScheduleEventsResponse> =
-        eventService.getRecordEvents(
-            page = page,
-            attended = attended,
-            category = category,
-        )
+    ) = eventService.getRecordEvents(
+        page = page,
+        attended = attended,
+        category = category,
+    )
 
     override suspend fun getEventDetail(
         eventId: String,
@@ -49,7 +49,7 @@ class EventDataSourceImpl @Inject constructor(
     override suspend fun getScheduleEvents(
         page: Int,
         category: String?,
-    ): BaseResponse<GetScheduleEventsResponse> = eventService.getScheduleEvents(
+    ) = eventService.getScheduleEvents(
         page = page,
         category = category,
     )

--- a/app/src/main/java/com/bongtu/baekseo/data/dto/auth/PostKakaoLoginResponse.kt
+++ b/app/src/main/java/com/bongtu/baekseo/data/dto/auth/PostKakaoLoginResponse.kt
@@ -14,7 +14,7 @@ data class PostKakaoLoginResponse (
     @SerialName("kakaoId")
     val kakaoId: String,
     @SerialName("apiKey")
-    val apiKey: String,
+    val apiKey: String? = null,
 ) {
     @Serializable
     data class TokenType(

--- a/app/src/main/java/com/bongtu/baekseo/data/dto/auth/PostKakaoLoginResponse.kt
+++ b/app/src/main/java/com/bongtu/baekseo/data/dto/auth/PostKakaoLoginResponse.kt
@@ -12,7 +12,9 @@ data class PostKakaoLoginResponse (
     @SerialName("isCompletedSignUp")
     val isCompletedSignUp: Boolean,
     @SerialName("kakaoId")
-    val kakaoId: Long,
+    val kakaoId: String,
+    @SerialName("apiKey")
+    val apiKey: String,
 ) {
     @Serializable
     data class TokenType(

--- a/app/src/main/java/com/bongtu/baekseo/data/dto/auth/PostSignUpRequest.kt
+++ b/app/src/main/java/com/bongtu/baekseo/data/dto/auth/PostSignUpRequest.kt
@@ -6,9 +6,9 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class PostSignUpRequest (
     @SerialName("kakaoId")
-    val kakaoId: Long,
+    val kakaoId: String,
     @SerialName("appleId")
-    val appleId: Long? = null,
+    val appleId: String? = null,
     @SerialName("memberName")
     val memberName: String,
     @SerialName("memberBirthday")

--- a/app/src/main/java/com/bongtu/baekseo/data/mapper/AuthMapper.kt
+++ b/app/src/main/java/com/bongtu/baekseo/data/mapper/AuthMapper.kt
@@ -11,6 +11,7 @@ fun PostKakaoLoginResponse.toModel() = KakaoLogin(
     refreshToken = token?.refreshToken?.token.orEmpty(),
     isCompletedSignUp = isCompletedSignUp,
     kakaoId = kakaoId,
+    apiKey = apiKey.orEmpty(),
 )
 
 fun PostTokenReissueResponse.toModel() = TokenReissue(

--- a/app/src/main/java/com/bongtu/baekseo/data/model/auth/KakaoLogin.kt
+++ b/app/src/main/java/com/bongtu/baekseo/data/model/auth/KakaoLogin.kt
@@ -6,4 +6,5 @@ data class KakaoLogin(
     val refreshToken: String,
     val isCompletedSignUp: Boolean,
     val kakaoId: String,
+    val apiKey: String,
 )

--- a/app/src/main/java/com/bongtu/baekseo/data/model/auth/KakaoLogin.kt
+++ b/app/src/main/java/com/bongtu/baekseo/data/model/auth/KakaoLogin.kt
@@ -5,5 +5,5 @@ data class KakaoLogin(
     val accessToken: String,
     val refreshToken: String,
     val isCompletedSignUp: Boolean,
-    val kakaoId: Long,
+    val kakaoId: String,
 )

--- a/app/src/main/java/com/bongtu/baekseo/data/repository/auth/AuthRepository.kt
+++ b/app/src/main/java/com/bongtu/baekseo/data/repository/auth/AuthRepository.kt
@@ -9,7 +9,7 @@ interface AuthRepository {
     ): Result<KakaoLogin>
 
     suspend fun postSignUp(
-        kakaoId: Long,
+        kakaoId: String,
         memberName: String,
         memberBirthday: String,
         memberIncome: String,

--- a/app/src/main/java/com/bongtu/baekseo/data/repositoryimpl/auth/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/bongtu/baekseo/data/repositoryimpl/auth/AuthRepositoryImpl.kt
@@ -27,7 +27,7 @@ class AuthRepositoryImpl @Inject constructor(
     }
 
     override suspend fun postSignUp(
-        kakaoId: Long,
+        kakaoId: String,
         memberName: String,
         memberBirthday: String,
         memberIncome: String,

--- a/app/src/main/java/com/bongtu/baekseo/data/service/event/EventService.kt
+++ b/app/src/main/java/com/bongtu/baekseo/data/service/event/EventService.kt
@@ -1,6 +1,7 @@
 package com.bongtu.baekseo.data.service.event
 
 import com.bongtu.baekseo.core.network.model.BaseResponse
+import com.bongtu.baekseo.core.network.model.BaseResponseWithoutData
 import com.bongtu.baekseo.data.dto.event.DeleteEventsRequest
 import com.bongtu.baekseo.data.dto.event.GetEventDetailResponse
 import com.bongtu.baekseo.data.dto.event.GetHomeEventsResponse
@@ -22,7 +23,7 @@ interface EventService {
     @POST("/api/v1/events")
     suspend fun postEventInfo(
         @Body request: PostEventInfoRequest,
-    ): BaseResponse<Unit>
+    ): BaseResponseWithoutData
 
     @POST("/api/v1/events/cost")
     suspend fun postEventCost(
@@ -42,12 +43,12 @@ interface EventService {
     suspend fun putEventInfo(
         @Path("eventId") eventId: String,
         @Body request: PutEventInfoRequest,
-    ): BaseResponse<Unit>
+    ): BaseResponseWithoutData
 
     @HTTP(method = "DELETE", path = "/api/v1/events", hasBody = true)
     suspend fun deleteEvents(
         @Body request: DeleteEventsRequest,
-    ): BaseResponse<Unit>
+    ): BaseResponseWithoutData
 
     @GET("/api/v1/events/history/{page}")
     suspend fun getRecordEvents(
@@ -64,5 +65,5 @@ interface EventService {
     @DELETE("/api/v1/events/{eventId}")
     suspend fun deleteEventInfo(
         @Path("eventId") eventId: String,
-    ): BaseResponse<Unit>
+    ): BaseResponseWithoutData
 }

--- a/app/src/main/java/com/bongtu/baekseo/domain/usecase/auth/SetKakaoLoginUseCase.kt
+++ b/app/src/main/java/com/bongtu/baekseo/domain/usecase/auth/SetKakaoLoginUseCase.kt
@@ -1,5 +1,6 @@
 package com.bongtu.baekseo.domain.usecase.auth
 
+import com.bongtu.baekseo.core.local.datastore.ApiKeyDataStore
 import com.bongtu.baekseo.core.local.datastore.TokenDataStore
 import com.bongtu.baekseo.core.local.datastore.UsernameDataStore
 import com.bongtu.baekseo.data.model.auth.KakaoLogin
@@ -9,6 +10,7 @@ import javax.inject.Inject
 class SetKakaoLoginUseCase @Inject constructor(
     private val authRepository: AuthRepository,
     private val tokenDataStore: TokenDataStore,
+    private val apiKeyDataStore: ApiKeyDataStore,
     private val usernameDataStore: UsernameDataStore,
 ) {
     suspend operator fun invoke(kakaoToken: String): Result<KakaoLogin> {
@@ -19,6 +21,7 @@ class SetKakaoLoginUseCase @Inject constructor(
                     refreshToken = response.refreshToken,
                 )
                 usernameDataStore.setUsername(response.name)
+                apiKeyDataStore.setApiKey(response.apiKey)
             }
     }
 }

--- a/app/src/main/java/com/bongtu/baekseo/presentation/edit/EditViewModel.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/edit/EditViewModel.kt
@@ -189,7 +189,6 @@ class EditViewModel @Inject constructor(
             event = state.toEvent(),
             location = state.toLocation(),
         ).onSuccess { response ->
-            Timber.tag("patchEditEventInformation").d("response: $response")
             navigateToComplete()
         }.onFailure {
             // TODO: 실패 처리
@@ -208,7 +207,6 @@ class EditViewModel @Inject constructor(
                 meetFrequency = DEFAULT_WEIGHT,
             ),
         ).onSuccess { response ->
-            Timber.tag("saveEditEventInformation").d("response: $response")
             navigateToComplete()
         }.onFailure {
             // TODO: 실패 처리

--- a/app/src/main/java/com/bongtu/baekseo/presentation/onboarding/OnBoardingContract.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/onboarding/OnBoardingContract.kt
@@ -9,7 +9,7 @@ class OnBoardingContract {
     data class OnBoardingUiState(
         val loadState: UiState<Nothing> = UiState.Empty,
         val kakaoLoginState: SocialLoginState = SocialLoginState.Idle,
-        val kakaoId: Long = 0L,
+        val kakaoId: String = "",
         val name: String = "",
         val birth: String = "",
         var dialogBirth: String = "",

--- a/app/src/main/java/com/bongtu/baekseo/presentation/onboarding/OnBoardingViewModel.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/onboarding/OnBoardingViewModel.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -70,6 +71,7 @@ class OnBoardingViewModel @Inject constructor(
                     }
                 }
                 .onFailure {
+                    Timber.d("kakaoLogin: $it")
                     _kakaoLoginState.tryEmit(SocialLoginState.Fail)
                 }
         }
@@ -100,7 +102,7 @@ class OnBoardingViewModel @Inject constructor(
             )
         }
 
-    private fun updateKakaoId(newKakaoId: Long) =
+    private fun updateKakaoId(newKakaoId: String) =
         _uiState.update {
             it.copy(kakaoId = newKakaoId)
         }

--- a/app/src/main/java/com/bongtu/baekseo/presentation/onboarding/OnBoardingViewModel.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/onboarding/OnBoardingViewModel.kt
@@ -3,6 +3,7 @@ package com.bongtu.baekseo.presentation.onboarding
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.bongtu.baekseo.core.common.state.UiState
+import com.bongtu.baekseo.core.local.datastore.ApiKeyDataStore
 import com.bongtu.baekseo.core.local.datastore.TokenDataStore
 import com.bongtu.baekseo.core.local.datastore.UsernameDataStore
 import com.bongtu.baekseo.core.util.TextFieldValidator.validateName
@@ -23,6 +24,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class OnBoardingViewModel @Inject constructor(
+    private val apiKeyDataStore: ApiKeyDataStore,
     private val usernameDataStore: UsernameDataStore,
     private val tokenDataStore: TokenDataStore,
     private val authRepository: AuthRepository,
@@ -85,6 +87,7 @@ class OnBoardingViewModel @Inject constructor(
                 memberIncome = uiState.value.income,
             ).onSuccess { response ->
                 saveUsername(response.name)
+                saveApiKey(response.apiKey)
                 tokenDataStore.setTokens(
                     accessToken = response.accessToken,
                     refreshToken = response.refreshToken,
@@ -115,5 +118,10 @@ class OnBoardingViewModel @Inject constructor(
     private fun saveUsername(name: String) =
         viewModelScope.launch {
             usernameDataStore.setUsername(name)
+        }
+
+    private fun saveApiKey(apiKey: String) =
+        viewModelScope.launch {
+            apiKeyDataStore.setApiKey(apiKey)
         }
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #157 

## Work Description ✏️
- kakaoId를 Long -> String 변경했습니다
- 응답에서 apiKey를 받도록 수정했습니다
   - ApiKeyDataStore에 저장 후 KakaoHeaderInterceptor에 추가했습니다
- 경조사 관련 data가 들어오지 않는 api 응답을 수정했습니다.
   - 수정된 api: 경조사 생성/경조사 수정/경조사 단일 삭제/경조사 복수 삭제

## Screenshot 📸
| View | Screenshot |
|------|------|
| Kakao Api Key | <video src="https://github.com/user-attachments/assets/e3a98ac5-695c-4e2a-a8e7-3455cf895b59" width="360"/> |

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢