### PR TITLE
[HOTFIX/#182] 상세보기 뷰 삭제 상태값 수정

### DIFF
--- a/app/src/main/java/com/bongtu/baekseo/presentation/detail/DetailContract.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/detail/DetailContract.kt
@@ -8,7 +8,7 @@ import com.bongtu.baekseo.data.model.event.Location
 class DetailContract {
     @Immutable
     data class DetailUiState(
-        val loadState: UiState<Unit> = UiState.Loading,
+        val loadState: UiState<Unit> = UiState.Empty,
         val eventId: String = "",
         val hostName: String = "",
         val hostNickname: String = "",

--- a/app/src/main/java/com/bongtu/baekseo/presentation/detail/DetailScreen.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/detail/DetailScreen.kt
@@ -151,7 +151,7 @@ private fun DetailScreen(
                 note = uiState.note,
                 locationInfo = uiState.locationInfo,
             ),
-            isButtonEnabled = uiState.loadState !is UiState.Loading,
+            isDeleteButtonEnabled = uiState.loadState !is UiState.Loading,
             onDeleteButtonClick = { onRemoveButtonClick(uiState.eventId) },
             modifier = Modifier
                 .weight(1f),
@@ -162,7 +162,7 @@ private fun DetailScreen(
 @Composable
 private fun DetailContent(
     event: DetailEvent,
-    isButtonEnabled: Boolean,
+    isDeleteButtonEnabled: Boolean,
     onDeleteButtonClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -249,14 +249,13 @@ private fun DetailContent(
                     color = BongBaekTheme.colors.secondaryRed,
                     shape = RoundedCornerShape(10.dp),
                 ),
-            enabled = isButtonEnabled,
         )
 
         if (isDeleteAlertDialogVisible) {
             BongBaekDialog(
                 dialogType = DialogType.DELETE,
                 onDismissRequest = { isDeleteAlertDialogVisible = !isDeleteAlertDialogVisible },
-                onConfirmClick = onDeleteButtonClick,
+                onConfirmClick = if (isDeleteButtonEnabled) onDeleteButtonClick else ({}),
             )
         }
     }

--- a/app/src/main/java/com/bongtu/baekseo/presentation/detail/DetailScreen.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/detail/DetailScreen.kt
@@ -151,8 +151,10 @@ private fun DetailScreen(
                 note = uiState.note,
                 locationInfo = uiState.locationInfo,
             ),
-            isDeleteButtonEnabled = uiState.loadState !is UiState.Loading,
-            onDeleteButtonClick = { onRemoveButtonClick(uiState.eventId) },
+            onDeleteButtonClick = {
+                if (uiState.loadState !is UiState.Loading)
+                    onRemoveButtonClick(uiState.eventId)
+            },
             modifier = Modifier
                 .weight(1f),
         )
@@ -162,7 +164,6 @@ private fun DetailScreen(
 @Composable
 private fun DetailContent(
     event: DetailEvent,
-    isDeleteButtonEnabled: Boolean,
     onDeleteButtonClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -255,7 +256,7 @@ private fun DetailContent(
             BongBaekDialog(
                 dialogType = DialogType.DELETE,
                 onDismissRequest = { isDeleteAlertDialogVisible = !isDeleteAlertDialogVisible },
-                onConfirmClick = if (isDeleteButtonEnabled) onDeleteButtonClick else ({}),
+                onConfirmClick = onDeleteButtonClick,
             )
         }
     }


### PR DESCRIPTION
## Related issue 🛠
- closed #182

## Work Description ✏️
- 상세보기 뷰 삭제 상태 초기값을 UiState.Loading 에서 UiState.Empty 로 수정했습니다.
- 상세보기 뷰 삭제 button enabled 적용 위치를 버튼이 아닌 다이얼로그 버튼으로 수정 했습니다.

## Screenshot 📸
N/A

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
테스트를 제대로 다 해보지 못하여 생긴 실수 반성합니다ㅜ