### PR TITLE
[FIX/#184] 마이페이지 수정 사항 반영

### DIFF
--- a/app/src/main/java/com/bongtu/baekseo/presentation/mypage/MyPageViewModel.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/mypage/MyPageViewModel.kt
@@ -45,6 +45,11 @@ class MyPageViewModel @Inject constructor(
                         userIncome = IncomeType.getIncomeType(response.memberIncome),
                     )
                 }
+                updateOriginProfileState(
+                    newName = _uiState.value.userName,
+                    newBirth = uiState.value.userBirth,
+                    newIncome = uiState.value.userIncome,
+                )
                 updateMyPageLoadUiState(UiState.Success(Unit))
             }
             .onFailure {

--- a/app/src/main/java/com/bongtu/baekseo/presentation/mypage/ProfileEditScreen.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/mypage/ProfileEditScreen.kt
@@ -89,14 +89,6 @@ fun ProfileEditRoute(
             }
     }
 
-    LaunchedEffect(Unit) {
-        viewModel.updateOriginProfileState(
-            newName = uiState.userName,
-            newBirth = uiState.userBirth,
-            newIncome = uiState.userIncome,
-        )
-    }
-
     DisposableEffect(Unit) {
         onDispose {
             viewModel.updateOriginProfileState(

--- a/app/src/main/java/com/bongtu/baekseo/presentation/mypage/ProfileEditScreen.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/mypage/ProfileEditScreen.kt
@@ -304,7 +304,7 @@ private fun ProfileEditButton(
     val backgroundColor =
         if (selected) BongBaekTheme.colors.primaryBackground else BongBaekTheme.colors.gray750
     val borderColor =
-        if (selected) BongBaekTheme.colors.primaryNormal else BongBaekTheme.colors.gray100
+        if (selected) BongBaekTheme.colors.primaryNormal else BongBaekTheme.colors.lineNormal
 
     Row(
         modifier = modifier

--- a/app/src/main/java/com/bongtu/baekseo/presentation/mypage/ProfileEditScreen.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/mypage/ProfileEditScreen.kt
@@ -126,6 +126,7 @@ private fun ProfileEditScreen(
 ) {
     var isDatePickerDialogVisible by remember { mutableStateOf(false) }
     var switchChecked by remember { mutableStateOf(uiState.userIncome != IncomeType.NONE) }
+    val isIncomeSelectionInvalid = uiState.userIncome == IncomeType.NONE && switchChecked
     val focusManager = LocalFocusManager.current
     val density = LocalDensity.current
 
@@ -267,7 +268,7 @@ private fun ProfileEditScreen(
                     .padding(
                         bottom = 36.dp,
                     ),
-                enabled = isEditButtonEnabled,
+                enabled = isEditButtonEnabled && !isIncomeSelectionInvalid,
             )
         }
 

--- a/app/src/main/java/com/bongtu/baekseo/presentation/onboarding/OnBoardingSettingScreen.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/onboarding/OnBoardingSettingScreen.kt
@@ -89,6 +89,7 @@ fun OnBoardingSettingScreen(
 
     var isDatePickerDialogVisible by remember { mutableStateOf(false) }
     var switchChecked by remember { mutableStateOf(false) }
+    val isIncomeSelectionInvalid = uiState.income == IncomeType.NONE && switchChecked
 
     Column(
         modifier = modifier
@@ -236,7 +237,7 @@ fun OnBoardingSettingScreen(
                     .padding(
                         bottom = 38.dp,
                     ),
-                enabled = viewModel.updateButtonState(),
+                enabled = viewModel.updateButtonState() && !isIncomeSelectionInvalid,
             )
         }
 


### PR DESCRIPTION
## Related issue 🛠
- closed #184

## Work Description ✏️
- 마이페이지에서 수정하기 진입시 일시적인 "수정하기" 버튼 활성화 제거
- 회원 정보 수정하기 수입 체크란 테두리 색상 gray100 -> line_normal 수정
- 온보딩 프로필 설정, 마이페이지 프로필 수정 스위치시 버튼 활성화 로직 수정

## Screenshot 📸

https://github.com/user-attachments/assets/4dff1274-8d13-4e3e-ba06-0b8de9b07bd6



## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
- N/A