### PR TITLE
[ADD] 개발 환경 세팅 자동화 파이프라인 구축

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -8,10 +8,15 @@ platform :android do
 
     github_token = UI.password("GitHub Access Token을 입력하세요: ")
 
+    ENV['GIT_ASKPASS'] = 'echo'
+    ENV['GIT_USERNAME'] = github_token
+    ENV['GIT_PASSWORD'] = github_token
+
     UI.message("1. 보안 파일(keystore, properties)을 다운로드합니다...")
     secrets_dir = "../temp-secrets"
+
     begin
-        sh "git clone https://#{github_token}@github.com/bongtubaekseo/BongBaek-Android-Secrets.git #{secrets_dir}"
+        sh "git clone https://github.com/bongtubaekseo/BongBaek-Android-Secrets.git #{secrets_dir}"
     rescue => ex
         UI.user_error!("보안 레포지토리(#{secrets_dir})를 clone하는 데 실패했습니다. Access Token이나 레포지토리 주소를 확인하세요.")
         raise ex
@@ -38,10 +43,7 @@ platform :android do
 
     UI.message("파일 복사 완료.")
 
-    UI.message("3. 임시 파일을 삭제합니다...")
-    sh "rm -rf #{secrets_dir}"
-
-    UI.message("4. Gradle 의존성을 동기화하고 초기 빌드를 수행합니다...")
+    UI.message("3. Gradle 의존성을 동기화하고 초기 빌드를 수행합니다...")
     begin
         gradle(task: "assembleDebug")
     rescue => ex

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -3,6 +3,61 @@ require 'json'
 default_platform(:android)
 
 platform :android do
+  desc "프로젝트 초기 개발 환경을 세팅하고 빌드합니다."
+  lane :setup_project do
+
+    github_token = UI.password("GitHub Access Token을 입력하세요: ")
+
+    UI.message("1. 보안 파일(keystore, properties)을 다운로드합니다...")
+    secrets_dir = "../temp-secrets"
+    begin
+        sh "git clone https://#{github_token}@github.com/bongtubaekseo/BongBaek-Android-Secrets.git #{secrets_dir}"
+    rescue => ex
+        UI.user_error!("보안 레포지토리(#{secrets_dir})를 clone하는 데 실패했습니다. Access Token이나 레포지토리 주소를 확인하세요.")
+        raise ex
+    end
+
+    UI.message("2. 설정 파일들을 프로젝트 위치로 복사합니다...")
+
+    sh "mkdir -p ../keystore"
+    sh "mkdir -p ../app/src/debug"
+    sh "mkdir -p ../app/src/release"
+    sh "mkdir -p ./keys"
+
+    sh "cp #{secrets_dir}/local.properties ../local.properties"
+
+    sh "cp #{secrets_dir}/keystores/bongbaek-debug-key.jks ../keystore/bongbaek-debug-key.jks"
+    sh "cp #{secrets_dir}/keystores/bongbaek-release-key.jks ../keystore/bongbaek-release-key.jks"
+
+    sh "cp #{secrets_dir}/build-types/debug/google-services.json ../app/src/debug/google-services.json"
+    sh "cp #{secrets_dir}/build-types/release/google-services.json ../app/src/release/google-services.json"
+
+    sh "cp #{secrets_dir}/fastlane-keys/.env ./.env"
+    sh "cp #{secrets_dir}/fastlane-keys/firebase-credentials.json ./keys/firebase-credentials.json"
+    sh "cp #{secrets_dir}/fastlane-keys/google-credentials.json ./keys/google-credentials.json"
+
+    UI.message("파일 복사 완료.")
+
+    UI.message("3. 임시 파일을 삭제합니다...")
+    sh "rm -rf #{secrets_dir}"
+
+    UI.message("4. Gradle 의존성을 동기화하고 초기 빌드를 수행합니다...")
+    begin
+        gradle(task: "assembleDebug")
+    rescue => ex
+        UI.user_error!("Gradle 빌드에 실패했습니다. 복사된 파일들이 올바른지 확인하세요.")
+        raise ex
+    end
+
+    UI.success("🎉 모든 개발 환경 세팅이 완료되었습니다!")
+
+    ensure
+      if File.directory?(secrets_dir)
+        UI.message("임시 파일(#{secrets_dir})을 정리합니다...")
+        sh "rm -rf #{secrets_dir}"
+      end
+  end
+
   private_lane :get_version_info do
     UI.message("버전 정보 가져오는 중...")
 
@@ -59,7 +114,7 @@ platform :android do
           aab: lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH],
           metadata_path: "fastlane/metadata/android",
           # 하기 release_status는 충분한 검증 이후 completed으로 수정
-          release_status: "drad",
+          release_status: "draft",
           # rollout: 0.3
       )
 

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -15,6 +15,14 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do
 
 ## Android
 
+### android setup_project
+
+```sh
+[bundle exec] fastlane android setup_project
+```
+
+프로젝트 초기 개발 환경을 세팅하고 빌드합니다.
+
 ### android qa
 
 ```sh


### PR DESCRIPTION
## Related issue 🛠
- closed #186 

## Work Description ✏️
이 기능이 필요할까? 라는 생각이 조금 들긴 했지만
개발 환경이 바뀔 경우 필요한 파일을 요청하거나 찾아야 한다는 점이 너무 귀찮을 것 같아서 기왕 Fastlane을 도입했으니 추가해봤습니다.

기본적으로 fastlane은 로컬에 깔려 있다는 전제하에, 터미널에 `fastlane (android) setup_project`(android는 생략 가능)를 입력하면 저희 organization에 있는 secrets 레포에 있는 파일들을 복사해오는 기능입니다.

여기서 2가지 준비물이 필요합니다.
1. github access token
    - 봉백 secrets 레포에 대한 fine grained token을 발급받아야 합니다. 요건 나중에 봇으로 대체하던가 해볼게요
2. 환경변수 설정
    - local.properties를 복사해오는 방식이기 때문에 기존 파일에 있는 sdk.dir이 사라져서 환경변수로 Android SDK 경로를 미리 지정해두어야 빌드 실패를 하지 않습니다.

## To Reviewers 📢
뭔가 간단해진 것 같으면서 준비해야할 게 더 생긴거 같긴한데ㅋ ㅋ 나중에 컴퓨터 바꾸면 한 번 써봅시다.