### PR TITLE
[REFACTOR/#222] 토큰 갱신  로직 적용

### DIFF
--- a/app/src/main/java/com/bongtu/baekseo/core/common/app/AppModule.kt
+++ b/app/src/main/java/com/bongtu/baekseo/core/common/app/AppModule.kt
@@ -1,0 +1,16 @@
+package com.bongtu.baekseo.core.common.app
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class AppModule {
+
+    @Binds
+    abstract fun bindAppRestarter(
+        impl: AppRestarterImpl,
+    ): AppRestarter
+}

--- a/app/src/main/java/com/bongtu/baekseo/core/common/app/AppRestarter.kt
+++ b/app/src/main/java/com/bongtu/baekseo/core/common/app/AppRestarter.kt
@@ -1,0 +1,5 @@
+package com.bongtu.baekseo.core.common.app
+
+interface AppRestarter {
+    fun restartApp(isStartLogin: Boolean)
+}

--- a/app/src/main/java/com/bongtu/baekseo/core/common/app/AppRestarterImpl.kt
+++ b/app/src/main/java/com/bongtu/baekseo/core/common/app/AppRestarterImpl.kt
@@ -1,0 +1,24 @@
+package com.bongtu.baekseo.core.common.app
+
+import android.content.Context
+import android.content.Intent
+import com.bongtu.baekseo.presentation.main.MainActivity
+import com.jakewharton.processphoenix.ProcessPhoenix
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+private const val IS_START_LOGIN = "is_start_login"
+
+class AppRestarterImpl @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : AppRestarter {
+
+    override fun restartApp(isStartLogin: Boolean) {
+        val intent = Intent(context, MainActivity::class.java).apply {
+            putExtra(IS_START_LOGIN, isStartLogin)
+            flags = Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK
+        }
+
+        ProcessPhoenix.triggerRebirth(context, intent)
+    }
+}

--- a/app/src/main/java/com/bongtu/baekseo/core/network/TokenAuthenticator.kt
+++ b/app/src/main/java/com/bongtu/baekseo/core/network/TokenAuthenticator.kt
@@ -17,8 +17,6 @@ class TokenAuthenticator @Inject constructor(
 ) : Authenticator {
 
     override fun authenticate(route: Route?, response: Response): Request? {
-        val previousToken = response.request.header(AUTHORIZATION_HEADER)
-
         if (responseCount(response) >= MAX_RESPONSE_COUNT) return null
 
         synchronized(this) {

--- a/app/src/main/java/com/bongtu/baekseo/core/network/TokenAuthenticator.kt
+++ b/app/src/main/java/com/bongtu/baekseo/core/network/TokenAuthenticator.kt
@@ -1,0 +1,76 @@
+package com.bongtu.baekseo.core.network
+
+import com.bongtu.baekseo.core.common.app.AppRestarter
+import com.bongtu.baekseo.core.local.datastore.TokenDataStore
+import com.bongtu.baekseo.data.repository.auth.AuthRepository
+import kotlinx.coroutines.runBlocking
+import okhttp3.Authenticator
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.Route
+import javax.inject.Inject
+
+class TokenAuthenticator @Inject constructor(
+    private val authRepository: AuthRepository,
+    private val appRestarter: AppRestarter,
+    private val tokenDataStore: TokenDataStore,
+) : Authenticator {
+
+    override fun authenticate(route: Route?, response: Response): Request? {
+        val previousToken = response.request.header(AUTHORIZATION_HEADER)
+
+        if (responseCount(response) >= MAX_RESPONSE_COUNT) return null
+
+        synchronized(this) {
+            val newAccessToken = runBlocking {
+                tryReissueToken()
+            } ?: return null
+
+            return response.request.newBuilder()
+                .header(AUTHORIZATION_HEADER, "$BEARER_PREFIX $newAccessToken")
+                .build()
+        }
+    }
+
+    private suspend fun tryReissueToken(): String? {
+        val refreshToken = tokenDataStore.getRefreshToken()
+            ?: return handleReissueFailure()
+
+        val result = authRepository.postTokenReissue(refreshToken)
+
+        return result.fold(
+            onSuccess = { tokenReissue ->
+                tokenDataStore.setTokens(
+                    accessToken = tokenReissue.accessToken,
+                    refreshToken = tokenReissue.refreshToken,
+                )
+                tokenReissue.accessToken
+            },
+            onFailure = {
+                handleReissueFailure()
+            }
+        )
+    }
+
+    private suspend fun handleReissueFailure(): String? {
+        tokenDataStore.clearInfo()
+        appRestarter.restartApp(isStartLogin = true)
+        return null
+    }
+
+    private fun responseCount(response: Response): Int {
+        var count = 1
+        var current = response.priorResponse
+        while (current != null) {
+            count++
+            current = current.priorResponse
+        }
+        return count
+    }
+
+    companion object {
+        private const val MAX_RESPONSE_COUNT = 2
+        private const val AUTHORIZATION_HEADER = "Authorization"
+        private const val BEARER_PREFIX = "Bearer "
+    }
+}

--- a/app/src/main/java/com/bongtu/baekseo/core/network/di/NetworkModule.kt
+++ b/app/src/main/java/com/bongtu/baekseo/core/network/di/NetworkModule.kt
@@ -7,6 +7,7 @@ import com.bongtu.baekseo.core.local.datastore.ApiKeyDataStore
 import com.bongtu.baekseo.core.local.datastore.TokenDataStore
 import com.bongtu.baekseo.core.network.HeaderInterceptor
 import com.bongtu.baekseo.core.network.KakaoHeaderInterceptor
+import com.bongtu.baekseo.core.network.TokenAuthenticator
 import com.bongtu.baekseo.core.network.isJsonArray
 import com.bongtu.baekseo.core.network.isJsonObject
 import com.bongtu.baekseo.core.network.qualifier.JWT
@@ -86,9 +87,11 @@ object NetworkModule {
     fun provideOkHttpClient(
         loggingInterceptor: Interceptor,
         @JWT headerInterceptor: Interceptor,
+        tokenAuthenticator: TokenAuthenticator,
     ): OkHttpClient = OkHttpClient.Builder()
         .addInterceptor(loggingInterceptor)
         .addInterceptor(headerInterceptor)
+        .authenticator(tokenAuthenticator)
         .build()
 
     @Provides

--- a/app/src/main/java/com/bongtu/baekseo/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/bongtu/baekseo/presentation/main/MainActivity.kt
@@ -1,21 +1,22 @@
 package com.bongtu.baekseo.presentation.main
 
-import android.content.Context
-import android.content.Intent
-import android.graphics.Color
 import android.os.Bundle
 import androidx.activity.ComponentActivity
-import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import com.bongtu.baekseo.core.common.app.AppRestarter
 import com.bongtu.baekseo.core.designsystem.theme.BongBaekTheme
-import com.jakewharton.processphoenix.ProcessPhoenix
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 private const val IS_START_LOGIN = "is_start_login"
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
+    @Inject
+    lateinit var appRestarter: AppRestarter
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -23,24 +24,16 @@ class MainActivity : ComponentActivity() {
 
         enableEdgeToEdge()
         window.isNavigationBarContrastEnforced = false
-        
+
         setContent {
             BongBaekTheme {
                 MainScreen(
                     isStartLogin = isStartLogin,
                     onRestartApp = {
-                        restartApp(this, it)
+                        appRestarter.restartApp(isStartLogin = it)
                     },
                 )
             }
         }
-    }
-
-    private fun restartApp(context: Context, isStartLogin: Boolean) {
-        val intent = Intent(context, this::class.java).apply {
-            putExtra(IS_START_LOGIN, isStartLogin)
-            flags = Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK
-        }
-        ProcessPhoenix.triggerRebirth(context, intent)
     }
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #222

## Work Description ✏️
- accesstoken 401 발생시 refreshtoken 재발급
- refreshtoken 재발급 실패시 app restart  

## Screenshot 📸
N/A

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
동기 인터페이스인 Authenticator 내부에서 runBlocking을 사용하여 스레드를 차단하는 구조적 문제 때문에
datastore 및 api 호출 로직을 동기적으로 변경하려고 했으나 부가적으로 수정해야할 부분이 많아져서 우선 runBlocking 방식으로 구현해 두었습니다.
실제 회원 탈퇴를 의도적으로 주어서 테스트 해보았는데 정상적으로 app restart 되는 것을 확인했습니다. 필요하다면 나중에 영상올려놓을게요.